### PR TITLE
Bah 1649 - Upgrading episodes artifact version to 1.0.1-SNAPSHOT

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ master ]
+    branches: [ master, OMRS-master-2.4 ]
   
 jobs:
   build-publish-package:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ master, OMRS-master-2.4 ]
+    branches: [ OMRS-master-2.4 ]
   
 jobs:
   build-publish-package:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>episodes</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>episodes-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,5 +32,11 @@
 			<artifactId>openmrs-web</artifactId>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>${javaxServletVersion}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>episodes</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>episodes-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>episodes</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Episodes of Care Module</name>
 	<description>Implementation of Episodes of Care for OpenMRS</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<junitVersion>4.13</junitVersion>
 		<powerMockVersion>1.7.4</powerMockVersion>
 		<mockitoVersion>3.5.11</mockitoVersion>
+		<javaxServletVersion>4.0.1</javaxServletVersion>
 	</properties>
 
 	<profiles>
@@ -71,6 +72,12 @@
 				<artifactId>openmrs-web</artifactId>
 				<version>${openmrs.platform.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>servlet-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.test</groupId>
@@ -92,6 +99,12 @@
 				<type>test-jar</type>
 				<version>${openmrs.platform.version}</version>
 				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>servlet-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
This PR is about

- Upgrading episodes artefact version to 1.0.1-SNAPSHOT
- Adds OMRS-master-2.4 branch in Github workflow
- Adds javax servlet-api dependency to resolve HttpServletResponse compile time issue