### PR TITLE
BAH-4319 | Initialize service and dao beans through moduleApplicationContext.xml

### DIFF
--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeAttributeTypeDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeAttributeTypeDaoImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public class EpisodeAttributeTypeDaoImpl implements EpisodeAttributeTypeDao {
 
     private static final String HQL_SELECT_ALL_EPISODE_ATTRIBUTE_TYPE = "FROM EpisodeAttributeType";
@@ -19,6 +18,10 @@ public class EpisodeAttributeTypeDaoImpl implements EpisodeAttributeTypeDao {
 
 
     private SessionFactory sessionFactory;
+
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
 
     public EpisodeAttributeTypeDaoImpl(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;

--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeAttributeTypeDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeAttributeTypeDaoImpl.java
@@ -19,10 +19,6 @@ public class EpisodeAttributeTypeDaoImpl implements EpisodeAttributeTypeDao {
 
     private SessionFactory sessionFactory;
 
-    public void setSessionFactory(SessionFactory sessionFactory) {
-        this.sessionFactory = sessionFactory;
-    }
-
     public EpisodeAttributeTypeDaoImpl(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
     }

--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeDAOImpl.java
@@ -11,11 +11,13 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public class EpisodeDAOImpl implements EpisodeDAO {
 
-    @Autowired
     private SessionFactory sessionFactory;
+
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
 
     @Override
     public void save(Episode episode) {

--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeDAOImpl.java
@@ -15,7 +15,7 @@ public class EpisodeDAOImpl implements EpisodeDAO {
 
     private SessionFactory sessionFactory;
 
-    public void setSessionFactory(SessionFactory sessionFactory) {
+    public EpisodeDAOImpl(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
     }
 

--- a/api/src/main/java/org/openmrs/module/episodes/service/EpisodeAttributeTypeService.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/EpisodeAttributeTypeService.java
@@ -1,6 +1,5 @@
 package org.openmrs.module.episodes.service;
 
-import org.openmrs.ConceptAttributeType;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.module.episodes.EpisodeAttributeType;
 import org.springframework.transaction.annotation.Transactional;

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeAttributeTypeServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeAttributeTypeServiceImpl.java
@@ -11,11 +11,14 @@ import javax.validation.constraints.NotBlank;
 import java.util.Date;
 import java.util.List;
 
-@Service
 @Transactional
 public class EpisodeAttributeTypeServiceImpl implements EpisodeAttributeTypeService {
 
     private EpisodeAttributeTypeDao episodeAttributeTypeDao;
+
+    public void setEpisodeAttributeTypeDao(EpisodeAttributeTypeDao episodeAttributeTypeDao) {
+        this.episodeAttributeTypeDao = episodeAttributeTypeDao;
+    }
 
     public EpisodeAttributeTypeServiceImpl(EpisodeAttributeTypeDao episodeAttributeTypeDao) {
         this.episodeAttributeTypeDao = episodeAttributeTypeDao;

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeAttributeTypeServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeAttributeTypeServiceImpl.java
@@ -16,10 +16,6 @@ public class EpisodeAttributeTypeServiceImpl implements EpisodeAttributeTypeServ
 
     private EpisodeAttributeTypeDao episodeAttributeTypeDao;
 
-    public void setEpisodeAttributeTypeDao(EpisodeAttributeTypeDao episodeAttributeTypeDao) {
-        this.episodeAttributeTypeDao = episodeAttributeTypeDao;
-    }
-
     public EpisodeAttributeTypeServiceImpl(EpisodeAttributeTypeDao episodeAttributeTypeDao) {
         this.episodeAttributeTypeDao = episodeAttributeTypeDao;
     }

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeServiceImpl.java
@@ -11,11 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Component
 @Transactional
 public class EpisodeServiceImpl implements EpisodeService {
-    @Autowired
+
     private EpisodeDAO episodeDAO;
+
+    public void setEpisodeDAO(EpisodeDAO episodeDAO) {
+        this.episodeDAO = episodeDAO;
+    }
 
     @Override
     public void save(Episode episode) {

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeServiceImpl.java
@@ -16,7 +16,7 @@ public class EpisodeServiceImpl implements EpisodeService {
 
     private EpisodeDAO episodeDAO;
 
-    public void setEpisodeDAO(EpisodeDAO episodeDAO) {
+    public EpisodeServiceImpl(EpisodeDAO episodeDAO) {
         this.episodeDAO = episodeDAO;
     }
 

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -25,4 +25,73 @@
 
 	<context:component-scan base-package="org.openmrs.module.episodes"/>
 
+	<bean id="episodeDao" class="org.openmrs.module.episodes.dao.impl.EpisodeDAOImpl">
+		<property name="sessionFactory">
+			<ref bean="sessionFactory"/>
+		</property>
+	</bean>
+	<bean id="episodeAttributeTypeDao" class="org.openmrs.module.episodes.dao.impl.EpisodeAttributeTypeDaoImpl">
+		<property name="sessionFactory">
+			<ref bean="sessionFactory"/>
+		</property>
+	</bean>
+
+	<bean id="episodeService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager">
+			<ref bean="transactionManager"/>
+		</property>
+		<property name="target">
+			<bean class="org.openmrs.module.episodes.service.impl.EpisodeServiceImpl">
+				<property name="episodeDAO">
+					<ref bean="episodeDao"/>
+				</property>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors"/>
+		</property>
+		<property name="transactionAttributeSource">
+			<ref bean="transactionAttributeSource"/>
+		</property>
+	</bean>
+
+	<bean id="episodeAttributeTypeService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager">
+			<ref bean="transactionManager"/>
+		</property>
+		<property name="target">
+			<bean class="org.openmrs.module.episodes.service.impl.EpisodeAttributeTypeServiceImpl">
+				<property name="episodeAttributeTypeDao">
+					<ref bean="episodeAttributeTypeDao"/>
+				</property>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors"/>
+		</property>
+		<property name="transactionAttributeSource">
+			<ref bean="transactionAttributeSource"/>
+		</property>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.episodes.service.EpisodeService</value>
+				<ref bean="episodeService"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.episodes.service.EpisodeAttributeTypeService</value>
+				<ref bean="episodeAttributeTypeService"/>
+			</list>
+		</property>
+	</bean>
+
+
+
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -23,17 +23,11 @@
   		    http://www.springframework.org/schema/util
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
-	<context:component-scan base-package="org.openmrs.module.episodes"/>
-
 	<bean id="episodeDao" class="org.openmrs.module.episodes.dao.impl.EpisodeDAOImpl">
-		<property name="sessionFactory">
-			<ref bean="sessionFactory"/>
-		</property>
+		<constructor-arg name="sessionFactory"  ref="sessionFactory"/>
 	</bean>
 	<bean id="episodeAttributeTypeDao" class="org.openmrs.module.episodes.dao.impl.EpisodeAttributeTypeDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="sessionFactory"/>
-		</property>
+		<constructor-arg name="sessionFactory"  ref="sessionFactory"/>
 	</bean>
 
 	<bean id="episodeService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
@@ -42,9 +36,7 @@
 		</property>
 		<property name="target">
 			<bean class="org.openmrs.module.episodes.service.impl.EpisodeServiceImpl">
-				<property name="episodeDAO">
-					<ref bean="episodeDao"/>
-				</property>
+				<constructor-arg name="episodeDAO" ref="episodeDao"/>
 			</bean>
 		</property>
 		<property name="preInterceptors">
@@ -61,9 +53,7 @@
 		</property>
 		<property name="target">
 			<bean class="org.openmrs.module.episodes.service.impl.EpisodeAttributeTypeServiceImpl">
-				<property name="episodeAttributeTypeDao">
-					<ref bean="episodeAttributeTypeDao"/>
-				</property>
+				<constructor-arg name="episodeAttributeTypeDao" ref="episodeAttributeTypeDao"/>
 			</bean>
 		</property>
 		<property name="preInterceptors">


### PR DESCRIPTION
This PR removes the use of Spring annotations for initialising service and dao. The beans are defined through  moduleApplicationContext.xml injecting OpenMRS service interceptors. This also makes the service available on OpenMRS service context.
