### PR TITLE
BAH-4876 | Add. Episode Of Care Search

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,6 +20,10 @@
     </licenses>
     <dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>
 		</dependency>

--- a/api/src/main/java/org/openmrs/module/episodes/dao/EpisodeSearchDAO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/EpisodeSearchDAO.java
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.dao;
+
+import org.openmrs.module.episodes.Episode;
+import org.openmrs.module.episodes.search.BuiltQuery;
+
+import java.util.List;
+
+public interface EpisodeSearchDAO {
+
+    List<Episode> search(BuiltQuery builtQuery);
+}

--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeSearchDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/EpisodeSearchDAOImpl.java
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.dao.impl;
+
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
+import org.openmrs.module.episodes.Episode;
+import org.openmrs.module.episodes.dao.EpisodeSearchDAO;
+import org.openmrs.module.episodes.search.BuiltQuery;
+
+import java.util.List;
+import java.util.Map;
+
+public class EpisodeSearchDAOImpl implements EpisodeSearchDAO {
+
+    private final SessionFactory sessionFactory;
+
+    public EpisodeSearchDAOImpl(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<Episode> search(BuiltQuery builtQuery) {
+        Query query = sessionFactory.getCurrentSession().createQuery(builtQuery.getHql());
+        for (Map.Entry<String, Object> entry : builtQuery.getParameters().entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
+        }
+        return query.list();
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/BuiltQuery.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/BuiltQuery.java
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public class BuiltQuery {
+
+    private final String hql;
+    private final Map<String, Object> parameters;
+    private final String searchedAttributeTypeUuid;
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/CriteriaValidator.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/CriteriaValidator.java
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search;
+
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+import org.openmrs.module.episodes.search.exceptions.SearchResponseErrorStatus;
+
+public class CriteriaValidator {
+
+    private static final String SUPPORTED_ENTITY = "episodeOfCare";
+
+    public void validate(SearchRequest request) {
+        if (request.getEntity() == null || request.getEntity().isEmpty()) {
+            throw new InvalidSearchCriteriaException("Request must include 'entity'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        if (!SUPPORTED_ENTITY.equals(request.getEntity())) {
+            throw new InvalidSearchCriteriaException(
+                    "Entity '" + request.getEntity() + "' is not handled by this endpoint. Expected: episodeOfCare", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        if (request.getCriteria() == null) {
+            throw new InvalidSearchCriteriaException("Request must include 'criteria'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        validateCondition(request.getCriteria());
+    }
+
+    private void validateCondition(Condition condition) {
+        if (condition.isLeaf()) {
+            validateLeaf(condition);
+        } else if (condition.isGroup()) {
+            validateGroup(condition);
+        } else {
+            throw new InvalidSearchCriteriaException(
+                    "Each condition must be either a leaf {field, comparator, value} or a group {operator, conditions}", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateLeaf(Condition leaf) {
+        if (leaf.getComparator() == null) {
+            throw new InvalidSearchCriteriaException(
+                    "Leaf condition for field '" + leaf.getField() + "' is missing or has an unknown 'comparator'. Supported: eq, gt, lt", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        if (leaf.getValue() == null || leaf.getValue().isEmpty()) {
+            throw new InvalidSearchCriteriaException(
+                    "Leaf condition for field '" + leaf.getField() + "' is missing 'value'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateGroup(Condition group) {
+        if (!group.getOperator().isSupported()) {
+            throw new InvalidSearchCriteriaException(
+                    "Operator '" + group.getOperator() + "' is not supported. Only 'AND' is allowed.", SearchResponseErrorStatus.UNPROCESSABLE_ENTITY);
+        }
+        if (group.getConditions() == null || group.getConditions().isEmpty()) {
+            throw new InvalidSearchCriteriaException("A group condition must have at least one condition in 'conditions'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        for (Condition child : group.getConditions()) {
+            validateCondition(child);
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/EpisodeSearchQueryBuilder.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/EpisodeSearchQueryBuilder.java
@@ -1,0 +1,221 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search;
+
+import org.openmrs.module.episodes.search.constants.SearchFields;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.FieldComparator;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+import org.openmrs.module.episodes.search.exceptions.SearchResponseErrorStatus;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+
+public class EpisodeSearchQueryBuilder {
+
+    private enum JoinKey { PP, PS, PI, PPA }
+
+    private enum FieldType { TEXT, DATE }
+
+    private static String toHqlOp(FieldComparator comparator) {
+        switch (comparator) {
+            case EQ: return "=";
+            case GT: return ">";
+            case LT: return "<";
+            default: throw new InvalidSearchCriteriaException("Unsupported comparator: " + comparator, SearchResponseErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private static class FieldDescriptor {
+        final Set<FieldComparator> allowedComparators;
+        final Set<JoinKey> requiredJoins;
+        final BinaryOperator<String> fragmentFn;
+        final FieldType valueType;
+
+        FieldDescriptor(Set<FieldComparator> comparators, Set<JoinKey> joins,
+                BinaryOperator<String> fn, FieldType valueType) {
+            this.allowedComparators = comparators;
+            this.requiredJoins = joins;
+            this.fragmentFn = fn;
+            this.valueType = valueType;
+        }
+    }
+
+    private static final Map<String, FieldDescriptor> FIELD_REGISTRY = new HashMap<>();
+
+    static {
+        FIELD_REGISTRY.put(SearchFields.EpisodeOfCare.START_DATE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.GT, FieldComparator.LT),
+                EnumSet.noneOf(JoinKey.class),
+                (op, p) -> "e.dateStarted " + op + " :" + p,
+                FieldType.DATE
+        ));
+        FIELD_REGISTRY.put(SearchFields.EpisodeOfCare.END_DATE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.GT, FieldComparator.LT),
+                EnumSet.noneOf(JoinKey.class),
+                (op, p) -> "e.dateEnded " + op + " :" + p,
+                FieldType.DATE
+        ));
+        FIELD_REGISTRY.put(SearchFields.EpisodeOfCare.CARE_MANAGER, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.noneOf(JoinKey.class),
+                (op, p) -> "e.careManager.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.UUID, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP),
+                (op, p) -> "pp.program.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.TYPE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP),
+                (op, p) -> "pp.program.concept.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.LOCATION, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP),
+                (op, p) -> "pp.location.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.STATUS, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP, JoinKey.PS),
+                (op, p) -> "ps.state.concept.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.STATUS_DATE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.GT, FieldComparator.LT),
+                EnumSet.of(JoinKey.PP, JoinKey.PS),
+                (op, p) -> "ps.startDate " + op + " :" + p,
+                FieldType.DATE
+        ));
+        FIELD_REGISTRY.put(SearchFields.Patient.IDENTIFIER_KIND, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PI),
+                (op, p) -> "(pi.identifierType.uuid = :" + p + " OR pi.identifierType.name = :" + p + ")",
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Patient.IDENTIFIER_VALUE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PI),
+                (op, p) -> "pi.identifier " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.ATTRIBUTE_KIND, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP, JoinKey.PPA),
+                (op, p) -> "ppa.attributeType.uuid " + op + " :" + p,
+                FieldType.TEXT
+        ));
+        FIELD_REGISTRY.put(SearchFields.Program.ATTRIBUTE_VALUE, new FieldDescriptor(
+                EnumSet.of(FieldComparator.EQ),
+                EnumSet.of(JoinKey.PP, JoinKey.PPA),
+                (op, p) -> "ppa.valueReference " + op + " :" + p,
+                FieldType.TEXT
+        ));
+    }
+
+    public BuiltQuery build(Condition criteria) {
+        Set<JoinKey> requiredJoins = new LinkedHashSet<>();
+        List<String> fragments = new ArrayList<>();
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        int[] paramCounter = {0};
+        String[] searchedAttributeTypeUuid = {null};
+
+        processCondition(criteria, requiredJoins, fragments, parameters, paramCounter, searchedAttributeTypeUuid);
+
+        String hql = buildHql(requiredJoins, fragments);
+        return new BuiltQuery(hql, parameters, searchedAttributeTypeUuid[0]);
+    }
+
+    private void processCondition(Condition condition, Set<JoinKey> joins, List<String> fragments,
+            Map<String, Object> params, int[] counter, String[] attrTypeUuid) {
+        if (condition.isLeaf()) {
+            processLeaf(condition, joins, fragments, params, counter, attrTypeUuid);
+        } else {
+            for (Condition child : condition.getConditions()) {
+                processCondition(child, joins, fragments, params, counter, attrTypeUuid);
+            }
+        }
+    }
+
+    private void processLeaf(Condition leaf, Set<JoinKey> joins, List<String> fragments,
+            Map<String, Object> params, int[] counter, String[] attrTypeUuid) {
+        String field = leaf.getField();
+        FieldDescriptor descriptor = FIELD_REGISTRY.get(field);
+        if (descriptor == null) {
+            throw new InvalidSearchCriteriaException("Unknown search field: '" + field + "'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+
+        FieldComparator comparator = leaf.getComparator();
+        if (comparator == null) {
+            throw new InvalidSearchCriteriaException(
+                    "Unknown comparator for field '" + field + "'. Supported: eq, gt, lt", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+        if (!descriptor.allowedComparators.contains(comparator)) {
+            throw new InvalidSearchCriteriaException(
+                    "Comparator '" + comparator.name().toLowerCase() + "' is not supported for field '" + field + "'", SearchResponseErrorStatus.BAD_REQUEST);
+        }
+
+        if (SearchFields.Program.ATTRIBUTE_KIND.equals(field)) {
+            attrTypeUuid[0] = leaf.getValue();
+        }
+
+        joins.addAll(descriptor.requiredJoins);
+
+        String paramName = "param" + counter[0]++;
+        fragments.add(descriptor.fragmentFn.apply(toHqlOp(comparator), paramName));
+        params.put(paramName, parseValue(descriptor, leaf.getValue()));
+    }
+
+    private Object parseValue(FieldDescriptor descriptor, String value) {
+        if (descriptor.valueType == FieldType.DATE) {
+            try {
+                return new SimpleDateFormat("yyyy-MM-dd").parse(value);
+            } catch (ParseException e) {
+                throw new InvalidSearchCriteriaException(
+                        "Invalid date format: '" + value + "'. Expected yyyy-MM-dd", SearchResponseErrorStatus.BAD_REQUEST);
+            }
+        }
+        return value;
+    }
+
+    private String buildHql(Set<JoinKey> joins, List<String> fragments) {
+        StringBuilder sb = new StringBuilder("SELECT DISTINCT e FROM Episode e");
+
+        if (joins.contains(JoinKey.PP)) sb.append(" INNER JOIN e.patientPrograms pp");
+        if (joins.contains(JoinKey.PS)) sb.append(" INNER JOIN pp.states ps");
+        if (joins.contains(JoinKey.PI)) sb.append(" INNER JOIN e.patient ep INNER JOIN ep.identifiers pi");
+        if (joins.contains(JoinKey.PPA)) sb.append(" INNER JOIN pp.attributes ppa");
+
+        sb.append(" WHERE e.voided = false");
+
+        if (joins.contains(JoinKey.PP)) sb.append(" AND pp.voided = false");
+        if (joins.contains(JoinKey.PS)) sb.append(" AND ps.voided = false");
+        if (joins.contains(JoinKey.PI)) sb.append(" AND pi.voided = false");
+        if (joins.contains(JoinKey.PPA)) sb.append(" AND ppa.voided = false");
+
+        for (String fragment : fragments) sb.append(" AND ").append(fragment);
+
+        return sb.toString();
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/constants/EpisodeSearchPrivileges.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/constants/EpisodeSearchPrivileges.java
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.constants;
+
+public final class EpisodeSearchPrivileges {
+
+    public static final String GET_EPISODES = "Get Episodes";
+    public static final String GET_PROGRAMS = "Get Programs";
+    public static final String GET_PROVIDER_ATTRIBUTE_TYPES = "Get Provider Attribute Types";
+    public static final String GET_PATIENT_PROGRAM_ATTRIBUTE_TYPES = "Get Patient Program Attribute Types";
+    public static final String GET_PATIENT_PROGRAMS = "Get Patient Programs";
+    public static final String GET_PATIENTS = "Get Patients";
+    public static final String GET_PERSON_ATTRIBUTE_TYPES = "Get Person Attribute Types";
+
+    private EpisodeSearchPrivileges() {
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/constants/SearchFields.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/constants/SearchFields.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.constants;
+
+public final class SearchFields {
+
+    public static final class EpisodeOfCare {
+        public static final String START_DATE = "episodeOfCare.startDate";
+        public static final String END_DATE = "episodeOfCare.endDate";
+        public static final String CARE_MANAGER = "episodeOfCare.careManager";
+
+        private EpisodeOfCare() {
+        }
+    }
+
+    public static final class Program {
+        public static final String UUID = "program.uuid";
+        public static final String TYPE = "program.type";
+        public static final String LOCATION = "program.location";
+        public static final String STATUS = "program.status";
+        public static final String STATUS_DATE = "program.statusDate";
+        public static final String ATTRIBUTE_KIND = "program.attributeType.kind";
+        public static final String ATTRIBUTE_VALUE = "program.attributeType.value";
+
+        private Program() {
+        }
+    }
+
+    public static final class Patient {
+        public static final String IDENTIFIER_KIND = "patient.identifiers.kind";
+        public static final String IDENTIFIER_VALUE = "patient.identifiers.value";
+
+        private Patient() {
+        }
+    }
+
+    private SearchFields() {
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/criteria/Condition.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/criteria/Condition.java
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.criteria;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class Condition {
+
+    private String field;
+
+    @Setter(AccessLevel.NONE)
+    private FieldComparator comparator;
+
+    private String value;
+    private ConditionOperator operator;
+    private List<Condition> conditions;
+
+    public void setComparator(String comparator) {
+        this.comparator = FieldComparator.fromString(comparator);
+    }
+
+    public boolean isLeaf() {
+        return field != null && operator == null;
+    }
+
+    public boolean isGroup() {
+        return operator != null && field == null;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/criteria/ConditionOperator.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/criteria/ConditionOperator.java
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.criteria;
+
+public enum ConditionOperator {
+    AND, OR;
+
+    public boolean isSupported() {
+        return this == AND;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/criteria/FieldComparator.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/criteria/FieldComparator.java
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.criteria;
+
+public enum FieldComparator {
+
+    EQ, GT, LT;
+
+    public static FieldComparator fromString(String s) {
+        if (s == null) return null;
+        try {
+            return FieldComparator.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/criteria/SearchRequest.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/criteria/SearchRequest.java
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.criteria;
+
+import lombok.Data;
+
+@Data
+public class SearchRequest {
+
+    private String entity;
+    private Condition criteria;
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/EpisodeSearchResultDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/EpisodeSearchResultDTO.java
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.dto;
+
+import lombok.Data;
+
+@Data
+public class EpisodeSearchResultDTO {
+
+    private String uuid;
+    private String status;
+    private String dateStarted;
+    private String dateEnded;
+    private PatientDTO patient;
+    private ProgramDTO program;
+    private CareManagerDTO careManager;
+
+    @Data
+    public static class CareManagerDTO {
+        private String uuid;
+        private String display;
+        private String identifier;
+        private PersonDTO person;
+
+        @Data
+        public static class PersonDTO {
+            private String uuid;
+            private PersonNameDTO preferredName;
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/LocationRefDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/LocationRefDTO.java
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.dto;
+
+import lombok.Data;
+
+@Data
+public class LocationRefDTO {
+
+    private String uuid;
+    private String display;
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientDTO.java
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PatientDTO {
+
+    private String uuid;
+    private String display;
+    private List<IdentifierDTO> identifiers;
+    private PersonDTO person;
+    private boolean voided;
+
+    @Data
+    public static class IdentifierDTO {
+        private String display;
+        private String uuid;
+        private String identifier;
+        private IdentifierTypeDTO identifierType;
+        private LocationRefDTO location;
+        private boolean preferred;
+    }
+
+    @Data
+    public static class IdentifierTypeDTO {
+        private String uuid;
+        private String display;
+    }
+
+    @Data
+    public static class PersonDTO {
+        private String uuid;
+        private String display;
+        private String gender;
+        private Integer age;
+        private String birthdate;
+        private boolean birthdateEstimated;
+        private PersonNameDTO preferredName;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientDTO.java
@@ -17,7 +17,6 @@ import java.util.List;
 public class PatientDTO {
 
     private String uuid;
-    private String display;
     private List<IdentifierDTO> identifiers;
     private PersonDTO person;
     private boolean voided;
@@ -41,7 +40,6 @@ public class PatientDTO {
     @Data
     public static class PersonDTO {
         private String uuid;
-        private String display;
         private String gender;
         private Integer age;
         private String birthdate;

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientProgramDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientProgramDTO.java
@@ -14,27 +14,22 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class EpisodeSearchResultDTO {
+public class PatientProgramDTO {
 
     private String uuid;
-    private String status;
-    private String dateStarted;
-    private String dateEnded;
-    private PatientDTO patient;
-    private List<PatientProgramDTO> patientPrograms;
-    private CareManagerDTO careManager;
+    private LocationRefDTO location;
+    private List<ProgramAttributeDTO> attributes;
+    private ProgramDTO program;
 
     @Data
-    public static class CareManagerDTO {
+    public static class ProgramAttributeDTO {
+        private AttributeTypeRefDTO attributeType;
+        private String value;
         private String uuid;
-        private String display;
-        private String identifier;
-        private PersonDTO person;
 
         @Data
-        public static class PersonDTO {
+        public static class AttributeTypeRefDTO {
             private String uuid;
-            private PersonNameDTO preferredName;
         }
     }
 }

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientProgramDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PatientProgramDTO.java
@@ -20,6 +20,7 @@ public class PatientProgramDTO {
     private LocationRefDTO location;
     private List<ProgramAttributeDTO> attributes;
     private ProgramDTO program;
+    private CurrentStateDTO currentState;
 
     @Data
     public static class ProgramAttributeDTO {
@@ -30,6 +31,35 @@ public class PatientProgramDTO {
         @Data
         public static class AttributeTypeRefDTO {
             private String uuid;
+        }
+    }
+
+    @Data
+    public static class CurrentStateDTO {
+        private String uuid;
+        private String startDate;
+        private String endDate;
+        private WorkflowStateDTO state;
+        private WorkflowRefDTO workflow;
+
+        @Data
+        public static class WorkflowStateDTO {
+            private String uuid;
+            private ConceptRefDTO concept;
+            private boolean initial;
+            private boolean terminal;
+        }
+
+        @Data
+        public static class WorkflowRefDTO {
+            private String uuid;
+            private ConceptRefDTO concept;
+        }
+
+        @Data
+        public static class ConceptRefDTO {
+            private String uuid;
+            private String display;
         }
     }
 }

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PersonNameDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PersonNameDTO.java
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.dto;
+
+import lombok.Data;
+
+@Data
+public class PersonNameDTO {
+
+    private String display;
+    private String uuid;
+    private String givenName;
+    private String middleName;
+    private String familyName;
+    private String familyName2;
+    private boolean voided;
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/PersonNameDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/PersonNameDTO.java
@@ -14,7 +14,6 @@ import lombok.Data;
 @Data
 public class PersonNameDTO {
 
-    private String display;
     private String uuid;
     private String givenName;
     private String middleName;

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/ProgramDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/ProgramDTO.java
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ProgramDTO {
+
+    private String name;
+    private String uuid;
+    private boolean retired;
+    private String description;
+    private ConceptRefDTO concept;
+    private LocationRefDTO location;
+    private List<ProgramAttributeDTO> attributes;
+
+    @Data
+    public static class ConceptRefDTO {
+        private String uuid;
+        private String display;
+    }
+
+    @Data
+    public static class ProgramAttributeDTO {
+        private AttributeTypeRefDTO attributeType;
+        private String value;
+        private String uuid;
+
+        @Data
+        public static class AttributeTypeRefDTO {
+            private String uuid;
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/dto/ProgramDTO.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/dto/ProgramDTO.java
@@ -11,34 +11,18 @@ package org.openmrs.module.episodes.search.dto;
 
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 public class ProgramDTO {
 
-    private String name;
     private String uuid;
+    private String name;
     private boolean retired;
     private String description;
     private ConceptRefDTO concept;
-    private LocationRefDTO location;
-    private List<ProgramAttributeDTO> attributes;
 
     @Data
     public static class ConceptRefDTO {
         private String uuid;
         private String display;
-    }
-
-    @Data
-    public static class ProgramAttributeDTO {
-        private AttributeTypeRefDTO attributeType;
-        private String value;
-        private String uuid;
-
-        @Data
-        public static class AttributeTypeRefDTO {
-            private String uuid;
-        }
     }
 }

--- a/api/src/main/java/org/openmrs/module/episodes/search/exceptions/InvalidSearchCriteriaException.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/exceptions/InvalidSearchCriteriaException.java
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.exceptions;
+
+public class InvalidSearchCriteriaException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SearchResponseErrorStatus status;
+
+    public InvalidSearchCriteriaException(String message, SearchResponseErrorStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public SearchResponseErrorStatus getStatus() {
+        return status;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/search/exceptions/SearchResponseErrorStatus.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/exceptions/SearchResponseErrorStatus.java
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search.exceptions;
+
+public enum SearchResponseErrorStatus {
+
+    BAD_REQUEST(400),
+    UNPROCESSABLE_ENTITY(422);
+
+    private final int code;
+
+    SearchResponseErrorStatus(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/service/EpisodeSearchService.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/EpisodeSearchService.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.service;
+
+import org.openmrs.annotation.Authorized;
+import org.openmrs.module.episodes.search.constants.EpisodeSearchPrivileges;
+import org.openmrs.module.episodes.search.dto.EpisodeSearchResultDTO;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+
+import java.util.List;
+
+public interface EpisodeSearchService {
+
+    @Authorized(value = {
+            EpisodeSearchPrivileges.GET_EPISODES,
+            EpisodeSearchPrivileges.GET_PROGRAMS,
+            EpisodeSearchPrivileges.GET_PROVIDER_ATTRIBUTE_TYPES,
+            EpisodeSearchPrivileges.GET_PATIENT_PROGRAM_ATTRIBUTE_TYPES,
+            EpisodeSearchPrivileges.GET_PATIENT_PROGRAMS,
+            EpisodeSearchPrivileges.GET_PATIENTS,
+            EpisodeSearchPrivileges.GET_PERSON_ATTRIBUTE_TYPES
+    }, requireAll = true)
+    List<EpisodeSearchResultDTO> search(SearchRequest request);
+}

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImpl.java
@@ -1,0 +1,247 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.service.impl;
+
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PatientProgram;
+import org.openmrs.PersonName;
+import org.openmrs.Program;
+import org.openmrs.Provider;
+import org.openmrs.module.episodes.Episode;
+import org.openmrs.module.episodes.dao.EpisodeSearchDAO;
+import org.openmrs.module.episodes.search.BuiltQuery;
+import org.openmrs.module.episodes.search.CriteriaValidator;
+import org.openmrs.module.episodes.search.EpisodeSearchQueryBuilder;
+import org.openmrs.module.episodes.search.dto.EpisodeSearchResultDTO;
+import org.openmrs.module.episodes.search.dto.LocationRefDTO;
+import org.openmrs.module.episodes.search.dto.PatientDTO;
+import org.openmrs.module.episodes.search.dto.PatientProgramDTO;
+import org.openmrs.module.episodes.search.dto.PersonNameDTO;
+import org.openmrs.module.episodes.search.dto.ProgramDTO;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.service.EpisodeSearchService;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+public class EpisodeSearchServiceImpl implements EpisodeSearchService {
+
+    private final EpisodeSearchDAO episodeSearchDAO;
+    private final CriteriaValidator validator;
+    private final EpisodeSearchQueryBuilder queryBuilder;
+
+    public EpisodeSearchServiceImpl(EpisodeSearchDAO episodeSearchDAO) {
+        this.episodeSearchDAO = episodeSearchDAO;
+        this.validator = new CriteriaValidator();
+        this.queryBuilder = new EpisodeSearchQueryBuilder();
+    }
+
+    @Override
+    public List<EpisodeSearchResultDTO> search(SearchRequest request) {
+        validator.validate(request);
+        BuiltQuery builtQuery = queryBuilder.build(request.getCriteria());
+        List<Episode> episodes = episodeSearchDAO.search(builtQuery);
+        return toResultDTOs(episodes);
+    }
+
+    private List<EpisodeSearchResultDTO> toResultDTOs(List<Episode> episodes) {
+        List<EpisodeSearchResultDTO> results = new ArrayList<>();
+        for (Episode episode : episodes) {
+            results.add(toResultDTO(episode));
+        }
+        return results;
+    }
+
+    private EpisodeSearchResultDTO toResultDTO(Episode episode) {
+        EpisodeSearchResultDTO dto = new EpisodeSearchResultDTO();
+        dto.setUuid(episode.getUuid());
+        dto.setStatus(episode.getStatus() != null ? episode.getStatus().name() : null);
+        dto.setDateStarted(formatDate(episode.getDateStarted()));
+        dto.setDateEnded(formatDate(episode.getDateEnded()));
+
+        dto.setPatient(mapPatient(episode.getPatient()));
+        dto.setPatientPrograms(mapPatientPrograms(episode));
+        dto.setCareManager(mapCareManager(episode.getCareManager()));
+
+        return dto;
+    }
+
+    private PatientDTO mapPatient(Patient patient) {
+        if (patient == null) {
+            return null;
+        }
+        PatientDTO dto = new PatientDTO();
+        dto.setUuid(patient.getUuid());
+        dto.setVoided(patient.getVoided() != null && patient.getVoided());
+        dto.setIdentifiers(mapIdentifiers(patient));
+        dto.setPerson(mapPerson(patient));
+
+        return dto;
+    }
+
+    private List<PatientDTO.IdentifierDTO> mapIdentifiers(Patient patient) {
+        List<PatientDTO.IdentifierDTO> result = new ArrayList<>();
+        for (PatientIdentifier pi : patient.getActiveIdentifiers()) {
+            PatientDTO.IdentifierDTO idDto = new PatientDTO.IdentifierDTO();
+            idDto.setUuid(pi.getUuid());
+            idDto.setIdentifier(pi.getIdentifier());
+            idDto.setPreferred(Boolean.TRUE.equals(pi.getPreferred()));
+
+            PatientIdentifierType pit = pi.getIdentifierType();
+            if (pit != null) {
+                PatientDTO.IdentifierTypeDTO typeDto = new PatientDTO.IdentifierTypeDTO();
+                typeDto.setUuid(pit.getUuid());
+                typeDto.setDisplay(pit.getName());
+                idDto.setIdentifierType(typeDto);
+                idDto.setDisplay(pit.getName() + " = " + pi.getIdentifier());
+            }
+
+            Location loc = pi.getLocation();
+            if (loc != null) {
+                LocationRefDTO locDto = new LocationRefDTO();
+                locDto.setUuid(loc.getUuid());
+                locDto.setDisplay(loc.getName());
+                idDto.setLocation(locDto);
+            }
+
+            result.add(idDto);
+        }
+        return result;
+    }
+
+    private PatientDTO.PersonDTO mapPerson(Patient patient) {
+        PatientDTO.PersonDTO personDto = new PatientDTO.PersonDTO();
+        personDto.setUuid(patient.getUuid());
+        personDto.setGender(patient.getGender());
+        personDto.setAge(patient.getAge());
+        personDto.setBirthdate(formatDate(patient.getBirthdate()));
+        personDto.setBirthdateEstimated(Boolean.TRUE.equals(patient.getBirthdateEstimated()));
+
+        PersonName name = patient.getPersonName();
+        if (name != null) {
+            personDto.setPreferredName(buildPersonNameDTO(name));
+        }
+
+        return personDto;
+    }
+
+    private List<PatientProgramDTO> mapPatientPrograms(Episode episode) {
+        List<PatientProgramDTO> result = new ArrayList<>();
+        for (PatientProgram pp : episode.getPatientPrograms()) {
+            if (!pp.getVoided()) {
+                result.add(mapPatientProgram(pp));
+            }
+        }
+        return result;
+    }
+
+    private PatientProgramDTO mapPatientProgram(PatientProgram pp) {
+        PatientProgramDTO dto = new PatientProgramDTO();
+        dto.setUuid(pp.getUuid());
+
+        Location loc = pp.getLocation();
+        if (loc != null) {
+            LocationRefDTO locDto = new LocationRefDTO();
+            locDto.setUuid(loc.getUuid());
+            locDto.setDisplay(loc.getName());
+            dto.setLocation(locDto);
+        }
+
+        dto.setAttributes(mapProgramAttributes(pp));
+        dto.setProgram(mapProgram(pp.getProgram()));
+
+        return dto;
+    }
+
+    private ProgramDTO mapProgram(Program program) {
+        if (program == null) {
+            return null;
+        }
+        ProgramDTO dto = new ProgramDTO();
+        dto.setUuid(program.getUuid());
+        dto.setName(program.getName());
+        dto.setRetired(Boolean.TRUE.equals(program.getRetired()));
+        dto.setDescription(program.getDescription());
+
+        if (program.getConcept() != null) {
+            ProgramDTO.ConceptRefDTO conceptDto = new ProgramDTO.ConceptRefDTO();
+            conceptDto.setUuid(program.getConcept().getUuid());
+            if (program.getConcept().getName() != null) {
+                conceptDto.setDisplay(program.getConcept().getName().getName());
+            }
+            dto.setConcept(conceptDto);
+        }
+
+        return dto;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<PatientProgramDTO.ProgramAttributeDTO> mapProgramAttributes(PatientProgram pp) {
+        List<PatientProgramDTO.ProgramAttributeDTO> result = new ArrayList<>();
+        for (org.openmrs.attribute.Attribute<?, ?> attr : pp.getActiveAttributes()) {
+            PatientProgramDTO.ProgramAttributeDTO attrDto = new PatientProgramDTO.ProgramAttributeDTO();
+            attrDto.setUuid(attr.getUuid());
+            attrDto.setValue(attr.getValueReference());
+
+            PatientProgramDTO.ProgramAttributeDTO.AttributeTypeRefDTO typeRef =
+                    new PatientProgramDTO.ProgramAttributeDTO.AttributeTypeRefDTO();
+            typeRef.setUuid(attr.getAttributeType().getUuid());
+            attrDto.setAttributeType(typeRef);
+
+            result.add(attrDto);
+        }
+        return result;
+    }
+
+    private EpisodeSearchResultDTO.CareManagerDTO mapCareManager(Provider careManager) {
+        EpisodeSearchResultDTO.CareManagerDTO dto = new EpisodeSearchResultDTO.CareManagerDTO();
+        if (careManager != null) {
+            dto.setUuid(careManager.getUuid());
+            dto.setDisplay(careManager.getName());
+            dto.setIdentifier(careManager.getIdentifier());
+
+            if (careManager.getPerson() != null) {
+                EpisodeSearchResultDTO.CareManagerDTO.PersonDTO personDto =
+                        new EpisodeSearchResultDTO.CareManagerDTO.PersonDTO();
+                personDto.setUuid(careManager.getPerson().getUuid());
+                PersonName name = careManager.getPerson().getPersonName();
+                if (name != null) {
+                    personDto.setPreferredName(buildPersonNameDTO(name));
+                }
+                dto.setPerson(personDto);
+            }
+        }
+        return dto;
+    }
+
+    private PersonNameDTO buildPersonNameDTO(PersonName name) {
+        PersonNameDTO dto = new PersonNameDTO();
+        dto.setUuid(name.getUuid());
+        dto.setGivenName(name.getGivenName());
+        dto.setMiddleName(name.getMiddleName());
+        dto.setFamilyName(name.getFamilyName());
+        dto.setFamilyName2(name.getFamilyName2());
+        dto.setVoided(Boolean.TRUE.equals(name.getVoided()));
+        return dto;
+    }
+
+    private String formatDate(Date date) {
+        if (date == null) return null;
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(date);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImpl.java
@@ -9,13 +9,18 @@
 
 package org.openmrs.module.episodes.service.impl;
 
+import org.openmrs.Concept;
+import org.openmrs.ConceptName;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PatientProgram;
+import org.openmrs.PatientState;
 import org.openmrs.PersonName;
 import org.openmrs.Program;
+import org.openmrs.ProgramWorkflow;
+import org.openmrs.ProgramWorkflowState;
 import org.openmrs.Provider;
 import org.openmrs.module.episodes.Episode;
 import org.openmrs.module.episodes.dao.EpisodeSearchDAO;
@@ -33,6 +38,7 @@ import org.openmrs.module.episodes.service.EpisodeSearchService;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -162,8 +168,91 @@ public class EpisodeSearchServiceImpl implements EpisodeSearchService {
 
         dto.setAttributes(mapProgramAttributes(pp));
         dto.setProgram(mapProgram(pp.getProgram()));
+        dto.setCurrentState(findCurrentState(pp));
 
         return dto;
+    }
+
+    private PatientProgramDTO.CurrentStateDTO findCurrentState(PatientProgram pp) {
+        PatientState current = selectCurrentState(pp.getStates());
+        return current != null ? mapCurrentState(current) : null;
+    }
+
+    static PatientState selectCurrentState(Collection<PatientState> states) {
+        List<PatientState> active = new ArrayList<>();
+        List<PatientState> ended = new ArrayList<>();
+
+        for (PatientState state : states) {
+            if (state.getVoided()) continue;
+            if (state.getEndDate() == null) {
+                active.add(state);
+            } else {
+                ended.add(state);
+            }
+        }
+
+        return active.isEmpty() ? latestByEndDate(ended) : latestByStartDate(active);
+    }
+
+    private static PatientState latestByStartDate(List<PatientState> states) {
+        PatientState latest = states.get(0);
+        for (PatientState state : states) {
+            if (state.getStartDate() != null && latest.getStartDate() != null
+                    && state.getStartDate().after(latest.getStartDate())) {
+                latest = state;
+            }
+        }
+        return latest;
+    }
+
+    private static PatientState latestByEndDate(List<PatientState> states) {
+        if (states.isEmpty()) return null;
+        PatientState latest = states.get(0);
+        for (PatientState state : states) {
+            if (state.getEndDate().after(latest.getEndDate())) {
+                latest = state;
+            }
+        }
+        return latest;
+    }
+
+    private PatientProgramDTO.CurrentStateDTO mapCurrentState(PatientState patientState) {
+        PatientProgramDTO.CurrentStateDTO dto = new PatientProgramDTO.CurrentStateDTO();
+        dto.setUuid(patientState.getUuid());
+        dto.setStartDate(formatDate(patientState.getStartDate()));
+        dto.setEndDate(formatDate(patientState.getEndDate()));
+
+        ProgramWorkflowState workflowState = patientState.getState();
+        if (workflowState != null) {
+            PatientProgramDTO.CurrentStateDTO.WorkflowStateDTO stateDto =
+                    new PatientProgramDTO.CurrentStateDTO.WorkflowStateDTO();
+            stateDto.setUuid(workflowState.getUuid());
+            stateDto.setInitial(Boolean.TRUE.equals(workflowState.getInitial()));
+            stateDto.setTerminal(Boolean.TRUE.equals(workflowState.getTerminal()));
+            stateDto.setConcept(toConceptRef(workflowState.getConcept()));
+            dto.setState(stateDto);
+
+            ProgramWorkflow workflow = workflowState.getProgramWorkflow();
+            if (workflow != null) {
+                PatientProgramDTO.CurrentStateDTO.WorkflowRefDTO workflowDto =
+                        new PatientProgramDTO.CurrentStateDTO.WorkflowRefDTO();
+                workflowDto.setUuid(workflow.getUuid());
+                workflowDto.setConcept(toConceptRef(workflow.getConcept()));
+                dto.setWorkflow(workflowDto);
+            }
+        }
+
+        return dto;
+    }
+
+    private PatientProgramDTO.CurrentStateDTO.ConceptRefDTO toConceptRef(Concept concept) {
+        if (concept == null) return null;
+        PatientProgramDTO.CurrentStateDTO.ConceptRefDTO ref =
+                new PatientProgramDTO.CurrentStateDTO.ConceptRefDTO();
+        ref.setUuid(concept.getUuid());
+        ConceptName name = concept.getName();
+        if (name != null) ref.setDisplay(name.getName());
+        return ref;
     }
 
     private ProgramDTO mapProgram(Program program) {

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -23,6 +23,36 @@
   		    http://www.springframework.org/schema/util
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
+	<bean id="episodeSearchDao" class="org.openmrs.module.episodes.dao.impl.EpisodeSearchDAOImpl">
+		<constructor-arg name="sessionFactory" ref="sessionFactory"/>
+	</bean>
+
+	<bean id="episodeSearchService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager">
+			<ref bean="transactionManager"/>
+		</property>
+		<property name="target">
+			<bean class="org.openmrs.module.episodes.service.impl.EpisodeSearchServiceImpl">
+				<constructor-arg name="episodeSearchDAO" ref="episodeSearchDao"/>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors"/>
+		</property>
+		<property name="transactionAttributeSource">
+			<ref bean="transactionAttributeSource"/>
+		</property>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.episodes.service.EpisodeSearchService</value>
+				<ref bean="episodeSearchService"/>
+			</list>
+		</property>
+	</bean>
+
 	<bean id="episodeDao" class="org.openmrs.module.episodes.dao.impl.EpisodeDAOImpl">
 		<constructor-arg name="sessionFactory"  ref="sessionFactory"/>
 	</bean>

--- a/api/src/test/java/org/openmrs/module/episodes/dao/impl/EpisodeSearchDAOImplITTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/dao/impl/EpisodeSearchDAOImplITTest.java
@@ -1,0 +1,356 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.dao.impl;
+
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PatientProgram;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
+import org.openmrs.Provider;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.PersonService;
+import org.openmrs.api.ProgramWorkflowService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.module.episodes.Episode;
+import org.openmrs.module.episodes.search.constants.SearchFields;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.ConditionOperator;
+import org.openmrs.module.episodes.search.dto.EpisodeSearchResultDTO;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.service.EpisodeSearchService;
+import org.openmrs.module.episodes.service.EpisodeService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class EpisodeSearchDAOImplITTest extends BaseModuleContextSensitiveTest {
+
+    private static final String EQ = "eq";
+    private static final String GT = "gt";
+    private static final String LT = "lt";
+    private static final String DATE_FROM = "2024-01-01";
+    private static final String DATE_TO = "2024-12-31";
+
+    @Autowired
+    private EpisodeSearchService episodeSearchService;
+
+    @Autowired
+    private EpisodeService episodeService;
+
+    @Autowired
+    private ProgramWorkflowService programWorkflowService;
+
+    @Autowired
+    private ProviderService providerService;
+
+    @Autowired
+    private PersonService personService;
+
+    @Autowired
+    private PatientService patientService;
+
+    @Autowired
+    private LocationService locationService;
+
+    @Test
+    public void shouldReturnEpisodesLinkedToProgram() {
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = saveEpisodeWith(pp);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.Program.UUID, EQ, pp.getProgram().getUuid()))
+        );
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnOnlyEpisodesWithinStartDateRange() {
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = new Episode();
+        episode.addPatientProgram(pp);
+        episode.setDateStarted(date(2024, 6, 15));
+        episodeService.save(episode);
+
+        Episode outsideRange = new Episode();
+        outsideRange.addPatientProgram(pp);
+        outsideRange.setDateStarted(date(2023, 1, 1));
+        episodeService.save(outsideRange);
+
+        Condition range = group(
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM),
+                leaf(SearchFields.EpisodeOfCare.START_DATE, LT, DATE_TO)
+        );
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(requestWith(range));
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesAfterStartDate() {
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = new Episode();
+        episode.addPatientProgram(pp);
+        episode.setDateStarted(date(2024, 6, 15));
+        episodeService.save(episode);
+
+        Episode before = new Episode();
+        before.addPatientProgram(pp);
+        before.setDateStarted(date(2023, 1, 1));
+        episodeService.save(before);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM)));
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesBeforeStartDate() {
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode before = new Episode();
+        before.addPatientProgram(pp);
+        before.setDateStarted(date(2023, 1, 1));
+        episodeService.save(before);
+
+        Episode after = new Episode();
+        after.addPatientProgram(pp);
+        after.setDateStarted(date(2025, 6, 15));
+        episodeService.save(after);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.EpisodeOfCare.START_DATE, LT, DATE_FROM)));
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(before.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesForCareManager() {
+        Provider provider = createProvider("Dr Smith");
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = new Episode();
+        episode.addPatientProgram(pp);
+        episode.setCareManager(provider);
+        episodeService.save(episode);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.EpisodeOfCare.CARE_MANAGER, EQ, provider.getUuid()))
+        );
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+        assertThat(results.get(0).getCareManager().getUuid(), is(provider.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesByPatientIdentifierName() {
+        PatientIdentifierType identifierType = createIdentifierType("PASSPORT");
+        Patient patient = createPatientWithIdentifier(identifierType, "P12345");
+
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = new Episode();
+        episode.setPatient(patient);
+        episode.addPatientProgram(pp);
+        episodeService.save(episode);
+
+        Condition identifierSearch = group(
+                leaf(SearchFields.Patient.IDENTIFIER_KIND, EQ, "PASSPORT"),
+                leaf(SearchFields.Patient.IDENTIFIER_VALUE, EQ, "P12345")
+        );
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(requestWith(identifierSearch));
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesByPatientIdentifierUuid() {
+        PatientIdentifierType identifierType = createIdentifierType("TEST_ID_TYPE");
+        Patient patient = createPatientWithIdentifier(identifierType, "T99");
+
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = new Episode();
+        episode.setPatient(patient);
+        episode.addPatientProgram(pp);
+        episodeService.save(episode);
+
+        Condition identifierSearch = group(
+                leaf(SearchFields.Patient.IDENTIFIER_KIND, EQ, identifierType.getUuid()),
+                leaf(SearchFields.Patient.IDENTIFIER_VALUE, EQ, "T99")
+        );
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(requestWith(identifierSearch));
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldReturnEpisodesInProgramLocation() {
+        Location location = locationService.getLocation(1);
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        pp.setLocation(location);
+        programWorkflowService.savePatientProgram(pp);
+
+        Episode episode = saveEpisodeWith(pp);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.Program.LOCATION, EQ, location.getUuid()))
+        );
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getUuid(), is(episode.getUuid()));
+    }
+
+    @Test
+    public void shouldPopulatePatientAndProgramDataInResponse() {
+        PatientProgram pp = programWorkflowService.getPatientProgram(1);
+        Episode episode = saveEpisodeWith(pp);
+
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.Program.UUID, EQ, pp.getProgram().getUuid()))
+        );
+
+        EpisodeSearchResultDTO dto = results.get(0);
+        assertThat(dto.getPatient(), is(notNullValue()));
+        assertThat(dto.getPatient().getUuid(), is(notNullValue()));
+        assertThat(dto.getPatientPrograms(), is(notNullValue()));
+        assertThat(dto.getPatientPrograms().isEmpty(), is(false));
+        assertThat(dto.getPatientPrograms().get(0).getProgram(), is(notNullValue()));
+        assertThat(dto.getStatus(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNoCriteriaMatch() {
+        List<EpisodeSearchResultDTO> results = episodeSearchService.search(
+                requestWith(leaf(SearchFields.Program.UUID, EQ, "non-existent-uuid"))
+        );
+
+        assertThat(results.size(), is(0));
+    }
+
+    @Test(expected = InvalidSearchCriteriaException.class)
+    public void shouldThrowExceptionWhenOrOperatorIsUsed() {
+        Condition criteria = new Condition();
+        criteria.setOperator(ConditionOperator.OR);
+        criteria.setConditions(Arrays.asList(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM)));
+
+        episodeSearchService.search(requestWith(criteria));
+    }
+
+    @Test(expected = InvalidSearchCriteriaException.class)
+    public void shouldThrowExceptionForUnknownSearchField() {
+        episodeSearchService.search(requestWith(leaf("episode.unknownField", EQ, "value")));
+    }
+
+    @Test(expected = InvalidSearchCriteriaException.class)
+    public void shouldThrowExceptionForUnsupportedComparator() {
+        episodeSearchService.search(requestWith(leaf(SearchFields.Program.UUID, GT, "uuid")));
+    }
+
+    @Test(expected = InvalidSearchCriteriaException.class)
+    public void shouldThrowExceptionForInvalidDateFormat() {
+        episodeSearchService.search(requestWith(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, "01/01/2024")));
+    }
+
+    private Episode saveEpisodeWith(PatientProgram pp) {
+        Episode episode = new Episode();
+        episode.addPatientProgram(pp);
+        episode.setPatient(pp.getPatient());
+        episodeService.save(episode);
+        return episode;
+    }
+
+    private Provider createProvider(String name) {
+        Person person = new Person();
+        PersonName personName = new PersonName();
+        personName.setGivenName(name);
+        personName.setFamilyName("Provider");
+        person.addName(personName);
+        personService.savePerson(person);
+        Provider provider = new Provider();
+        provider.setPerson(person);
+        providerService.saveProvider(provider);
+        return provider;
+    }
+
+    private PatientIdentifierType createIdentifierType(String name) {
+        PatientIdentifierType type = new PatientIdentifierType();
+        type.setName(name);
+        type.setDescription("Test identifier type: " + name);
+        return patientService.savePatientIdentifierType(type);
+    }
+
+    private Patient createPatientWithIdentifier(PatientIdentifierType identifierType, String identifier) {
+        Patient patient = new Patient();
+        PersonName name = new PersonName();
+        name.setGivenName("Test");
+        name.setFamilyName("Patient");
+        patient.addName(name);
+        patient.setGender("M");
+
+        PatientIdentifier pi = new PatientIdentifier();
+        pi.setIdentifierType(identifierType);
+        pi.setIdentifier(identifier);
+        pi.setPreferred(true);
+        pi.setLocation(locationService.getLocation(1));
+        patient.addIdentifier(pi);
+
+        return patientService.savePatient(patient);
+    }
+
+    private Date date(int year, int month, int day) {
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        cal.set(year, month - 1, day, 0, 0, 0);
+        cal.set(java.util.Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    private SearchRequest requestWith(Condition criteria) {
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(criteria);
+        return request;
+    }
+
+    private Condition leaf(String field, String comparator, String value) {
+        Condition c = new Condition();
+        c.setField(field);
+        c.setComparator(comparator);
+        c.setValue(value);
+        return c;
+    }
+
+    private Condition group(Condition... children) {
+        Condition c = new Condition();
+        c.setOperator(ConditionOperator.AND);
+        c.setConditions(Arrays.asList(children));
+        return c;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/episodes/search/CriteriaValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/CriteriaValidatorTest.java
@@ -1,0 +1,171 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search;
+
+import org.openmrs.module.episodes.search.constants.SearchFields;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.ConditionOperator;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class CriteriaValidatorTest {
+
+    private static final String GT = "gt";
+    private static final String LT = "lt";
+    private static final String EQ = "eq";
+    private static final String DATE_FROM = "2024-01-01";
+    private static final String DATE_TO = "2024-12-31";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final CriteriaValidator validator = new CriteriaValidator();
+
+    @Test
+    public void shouldThrowWhenEntityIsMissing() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'entity'");
+
+        SearchRequest request = new SearchRequest();
+        request.setCriteria(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        validator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowWhenEntityIsNotSupported() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'patient'");
+
+        SearchRequest request = new SearchRequest();
+        request.setEntity("patient");
+        request.setCriteria(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        validator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowWhenCriteriaIsMissing() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'criteria'");
+
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+
+        validator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowWhenOrOperatorUsedAtRoot() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'OR'");
+
+        validator.validate(requestWith(group(ConditionOperator.OR,
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM))));
+    }
+
+    @Test
+    public void shouldThrowWhenOrOperatorUsedInNestedGroup() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'OR'");
+
+        Condition inner = group(ConditionOperator.OR,
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+        Condition outer = group(ConditionOperator.AND, inner);
+
+        validator.validate(requestWith(outer));
+    }
+
+    @Test
+    public void shouldThrowWhenLeafComparatorIsMissing() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("comparator");
+
+        Condition leaf = new Condition();
+        leaf.setField(SearchFields.EpisodeOfCare.START_DATE);
+        leaf.setValue(DATE_FROM);
+
+        validator.validate(requestWith(leaf));
+    }
+
+    @Test
+    public void shouldThrowWhenLeafValueIsMissing() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("value");
+
+        Condition leaf = new Condition();
+        leaf.setField(SearchFields.EpisodeOfCare.START_DATE);
+        leaf.setComparator(GT);
+
+        validator.validate(requestWith(leaf));
+    }
+
+    @Test
+    public void shouldThrowWhenGroupHasNoConditions() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("at least one condition");
+
+        validator.validate(requestWith(group(ConditionOperator.AND)));
+    }
+
+    @Test
+    public void shouldPassValidationForValidLeaf() {
+        validator.validate(requestWith(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM)));
+    }
+
+    @Test
+    public void shouldPassValidationForAndGroup() {
+        validator.validate(requestWith(group(ConditionOperator.AND,
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM),
+                leaf(SearchFields.EpisodeOfCare.START_DATE, LT, DATE_TO))));
+    }
+
+    @Test
+    public void shouldPassValidationForNestedAndGroups() {
+        Condition inner = group(ConditionOperator.AND,
+                leaf(SearchFields.Patient.IDENTIFIER_KIND, EQ, "NATIONAL_ID"),
+                leaf(SearchFields.Patient.IDENTIFIER_VALUE, EQ, "N456"));
+
+        Condition outer = group(ConditionOperator.AND,
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM),
+                inner);
+
+        validator.validate(requestWith(outer));
+    }
+
+    private SearchRequest requestWith(Condition criteria) {
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(criteria);
+        return request;
+    }
+
+    private Condition leaf(String field, String comparator, String value) {
+        Condition c = new Condition();
+        c.setField(field);
+        c.setComparator(comparator);
+        c.setValue(value);
+        return c;
+    }
+
+    private Condition group(ConditionOperator operator, Condition... children) {
+        Condition c = new Condition();
+        c.setOperator(operator);
+        c.setConditions(children.length > 0 ? Arrays.asList(children) : Collections.emptyList());
+        return c;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/episodes/search/EpisodeSearchQueryBuilderTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/EpisodeSearchQueryBuilderTest.java
@@ -1,0 +1,289 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.search;
+
+import org.openmrs.module.episodes.search.constants.SearchFields;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.ConditionOperator;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class EpisodeSearchQueryBuilderTest {
+
+    private static final String EQ = "eq";
+    private static final String GT = "gt";
+    private static final String LT = "lt";
+    private static final String DATE_FROM = "2024-01-01";
+    private static final String DATE_TO = "2024-12-31";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final EpisodeSearchQueryBuilder builder = new EpisodeSearchQueryBuilder();
+
+    @Test
+    public void shouldStartWithSelectDistinctFromEpisode() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        assertThat(result.getHql(), containsString("SELECT DISTINCT e FROM Episode e"));
+    }
+
+    @Test
+    public void shouldAlwaysExcludeVoidedEpisodes() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        assertThat(result.getHql(), containsString("WHERE e.voided = false"));
+    }
+
+    @Test
+    public void shouldProduceStartDateGtFragmentWithDateParameter() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        assertThat(result.getHql(), containsString("e.dateStarted > :param0"));
+        assertThat(result.getHql(), not(containsString("INNER JOIN")));
+        assertThat(result.getParameters().get("param0"), instanceOf(Date.class));
+    }
+
+    @Test
+    public void shouldProduceStartDateLtFragmentOnly() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, LT, DATE_TO));
+
+        assertThat(result.getHql(), containsString("e.dateStarted < :param0"));
+        assertThat(result.getHql(), not(containsString(">")));
+        assertThat(result.getParameters().size(), is(1));
+    }
+
+    @Test
+    public void shouldProduceEndDateGtFragment() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.END_DATE, GT, DATE_FROM));
+
+        assertThat(result.getHql(), containsString("e.dateEnded > :param0"));
+        assertThat(result.getParameters().get("param0"), instanceOf(Date.class));
+    }
+
+    @Test
+    public void shouldProduceEndDateLtFragment() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.END_DATE, LT, DATE_TO));
+
+        assertThat(result.getHql(), containsString("e.dateEnded < :param0"));
+        assertThat(result.getParameters().get("param0"), instanceOf(Date.class));
+    }
+
+    @Test
+    public void shouldBindCareManagerAsStringWithNoJoins() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.CARE_MANAGER, EQ, "provider-uuid"));
+
+        assertThat(result.getHql(), containsString("e.careManager.uuid = :param0"));
+        assertThat(result.getHql(), not(containsString("INNER JOIN")));
+        assertThat(result.getParameters().get("param0"), instanceOf(String.class));
+    }
+
+    @Test
+    public void shouldAddPpJoinWhenSearchingByProgramUuid() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.UUID, EQ, "program-uuid"));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patientPrograms pp"));
+        assertThat(result.getHql(), containsString("pp.program.uuid = :param0"));
+        assertThat(result.getHql(), containsString("pp.voided = false"));
+        assertThat(result.getParameters().get("param0"), instanceOf(String.class));
+    }
+
+    @Test
+    public void shouldAddPpJoinWhenSearchingByProgramType() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.TYPE, EQ, "concept-uuid"));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patientPrograms pp"));
+        assertThat(result.getHql(), containsString("pp.program.concept.uuid = :param0"));
+    }
+
+    @Test
+    public void shouldAddPpJoinWhenSearchingByProgramLocation() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.LOCATION, EQ, "location-uuid"));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patientPrograms pp"));
+        assertThat(result.getHql(), containsString("pp.location.uuid = :param0"));
+    }
+
+    @Test
+    public void shouldAddPpAndPsJoinsWhenSearchingByProgramStatus() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.STATUS, EQ, "concept-uuid"));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patientPrograms pp"));
+        assertThat(result.getHql(), containsString("INNER JOIN pp.states ps"));
+        assertThat(result.getHql(), containsString("ps.state.concept.uuid = :param0"));
+        assertThat(result.getHql(), containsString("pp.voided = false"));
+        assertThat(result.getHql(), containsString("ps.voided = false"));
+    }
+
+    @Test
+    public void shouldAddPsJoinWithDateParameterForStatusDateGt() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.STATUS_DATE, GT, DATE_FROM));
+
+        assertThat(result.getHql(), containsString("INNER JOIN pp.states ps"));
+        assertThat(result.getHql(), containsString("ps.startDate > :param0"));
+        assertThat(result.getParameters().get("param0"), instanceOf(Date.class));
+    }
+
+    @Test
+    public void shouldProduceStatusDateLtFragment() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.STATUS_DATE, LT, DATE_TO));
+
+        assertThat(result.getHql(), containsString("ps.startDate < :param0"));
+        assertThat(result.getParameters().get("param0"), instanceOf(Date.class));
+    }
+
+    @Test
+    public void shouldAddPiJoinWithOrClauseWhenSearchingByIdentifier() {
+        BuiltQuery result = builder.build(group(
+                leaf(SearchFields.Patient.IDENTIFIER_KIND, EQ, "NATIONAL_ID"),
+                leaf(SearchFields.Patient.IDENTIFIER_VALUE, EQ, "N456")
+        ));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patient ep INNER JOIN ep.identifiers pi"));
+        assertThat(result.getHql(), containsString("(pi.identifierType.uuid = :param0 OR pi.identifierType.name = :param0)"));
+        assertThat(result.getHql(), containsString("pi.identifier = :param1"));
+        assertThat(result.getHql(), containsString("pi.voided = false"));
+    }
+
+    @Test
+    public void shouldAddPpaJoinAndTrackAttributeTypeUuidWhenSearchingByAttribute() {
+        String attrTypeUuid = "attr-type-uuid";
+        BuiltQuery result = builder.build(group(
+                leaf(SearchFields.Program.ATTRIBUTE_KIND, EQ, attrTypeUuid),
+                leaf(SearchFields.Program.ATTRIBUTE_VALUE, EQ, "US")
+        ));
+
+        assertThat(result.getHql(), containsString("INNER JOIN pp.attributes ppa"));
+        assertThat(result.getHql(), containsString("ppa.attributeType.uuid = :param0"));
+        assertThat(result.getHql(), containsString("ppa.valueReference = :param1"));
+        assertThat(result.getHql(), containsString("ppa.voided = false"));
+        assertThat(result.getSearchedAttributeTypeUuid(), is(attrTypeUuid));
+    }
+
+    @Test
+    public void shouldNotSetAttributeTypeUuidWhenOnlyValueFieldIsPresent() {
+        BuiltQuery result = builder.build(leaf(SearchFields.Program.ATTRIBUTE_VALUE, EQ, "US"));
+
+        assertThat(result.getSearchedAttributeTypeUuid(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldNotDuplicatePpJoinForMultipleProgramFields() {
+        BuiltQuery result = builder.build(group(
+                leaf(SearchFields.Program.UUID, EQ, "prog-uuid"),
+                leaf(SearchFields.Program.TYPE, EQ, "concept-uuid"),
+                leaf(SearchFields.Program.LOCATION, EQ, "loc-uuid")
+        ));
+
+        int ppJoinCount = result.getHql().split("INNER JOIN e\\.patientPrograms pp", -1).length - 1;
+        assertThat(ppJoinCount, is(1));
+    }
+
+    @Test
+    public void shouldAddBothPpAndPiJoinsWhenCombiningProgramAndIdentifierSearch() {
+        BuiltQuery result = builder.build(group(
+                leaf(SearchFields.Program.UUID, EQ, "prog-uuid"),
+                leaf(SearchFields.Patient.IDENTIFIER_KIND, EQ, "NATIONAL_ID"),
+                leaf(SearchFields.Patient.IDENTIFIER_VALUE, EQ, "N456")
+        ));
+
+        assertThat(result.getHql(), containsString("INNER JOIN e.patientPrograms pp"));
+        assertThat(result.getHql(), containsString("INNER JOIN e.patient ep INNER JOIN ep.identifiers pi"));
+    }
+
+    @Test
+    public void shouldNameParametersSequentiallyAcrossMultipleCriteria() {
+        BuiltQuery result = builder.build(group(
+                leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM),
+                leaf(SearchFields.EpisodeOfCare.END_DATE, LT, DATE_TO),
+                leaf(SearchFields.Program.UUID, EQ, "prog-uuid")
+        ));
+
+        assertThat(result.getParameters().containsKey("param0"), is(true));
+        assertThat(result.getParameters().containsKey("param1"), is(true));
+        assertThat(result.getParameters().containsKey("param2"), is(true));
+        assertThat(result.getParameters().size(), is(3));
+    }
+
+    @Test
+    public void shouldReturnNullAttributeTypeUuidWhenNoAttributeSearched() {
+        BuiltQuery result = builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, DATE_FROM));
+
+        assertThat(result.getSearchedAttributeTypeUuid(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldThrowForUnknownSearchField() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("Unknown search field: 'patient.unknownField'");
+
+        builder.build(leaf("patient.unknownField", EQ, "value"));
+    }
+
+    @Test
+    public void shouldThrowWhenGtUsedOnTextField() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("not supported for field 'program.uuid'");
+
+        builder.build(leaf(SearchFields.Program.UUID, GT, "uuid"));
+    }
+
+    @Test
+    public void shouldThrowWhenEqUsedOnDateField() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("not supported for field 'episodeOfCare.startDate'");
+
+        builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, EQ, DATE_FROM));
+    }
+
+    @Test
+    public void shouldThrowWhenComparatorIsNull() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("Unknown comparator");
+
+        builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, null, DATE_FROM));
+    }
+
+    @Test
+    public void shouldThrowForInvalidDateFormat() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("Invalid date format");
+
+        builder.build(leaf(SearchFields.EpisodeOfCare.START_DATE, GT, "01/01/2024"));
+    }
+
+    private Condition leaf(String field, String comparator, String value) {
+        Condition c = new Condition();
+        c.setField(field);
+        c.setComparator(comparator);
+        c.setValue(value);
+        return c;
+    }
+
+    private Condition group(Condition... children) {
+        Condition c = new Condition();
+        c.setOperator(ConditionOperator.AND);
+        c.setConditions(Arrays.asList(children));
+        return c;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImplITTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImplITTest.java
@@ -1,0 +1,140 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.service.impl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.User;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.api.APIAuthenticationException;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.ConditionOperator;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.service.EpisodeSearchService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.fail;
+
+public class EpisodeSearchServiceImplITTest extends BaseModuleContextSensitiveTest {
+
+    private static final String TEST_PASSWORD = "Admin123!";
+
+    private static final String[] REQUIRED_PRIVILEGES = resolveRequiredPrivileges();
+
+    private static String[] resolveRequiredPrivileges() {
+        try {
+            return EpisodeSearchService.class
+                    .getMethod("search", SearchRequest.class)
+                    .getAnnotation(Authorized.class)
+                    .value();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Could not resolve @Authorized privileges from EpisodeSearchService", e);
+        }
+    }
+
+    @Autowired
+    private EpisodeSearchService episodeSearchService;
+
+    @Autowired
+    private UserService userService;
+
+    private final Map<String, User> usersWithoutPrivilege = new HashMap<>();
+
+    @Before
+    public void setUpRestrictedUsers() {
+        for (String privilege : REQUIRED_PRIVILEGES) {
+            usersWithoutPrivilege.put(privilege, createUserWithout(privilege));
+        }
+    }
+
+    @After
+    public void restoreAdminSession() {
+        Context.authenticate("admin", "test");
+    }
+
+    @Test
+    public void shouldDenyAccessWhenEachRequiredPrivilegeIsMissing() {
+        for (String missingPrivilege : REQUIRED_PRIVILEGES) {
+            User user = usersWithoutPrivilege.get(missingPrivilege);
+            Context.authenticate(user.getUsername(), TEST_PASSWORD);
+            try {
+                episodeSearchService.search(validRequest());
+                fail("Expected APIAuthenticationException when missing privilege: " + missingPrivilege);
+            } catch (APIAuthenticationException e) {
+                // expected
+            }
+            Context.authenticate("admin", "test");
+        }
+    }
+
+    private User createUserWithout(String missingPrivilege) {
+        Person person = new Person();
+        PersonName personName = new PersonName();
+        personName.setGivenName("Test");
+        personName.setFamilyName("User");
+        person.addName(personName);
+        person.setGender("M");
+        Context.getPersonService().savePerson(person);
+
+        Role role = new Role();
+        role.setRole("TestRole_" + UUID.randomUUID());
+        role.setDescription("All required privileges except: " + missingPrivilege);
+
+        Set<Privilege> privileges = new HashSet<>();
+        for (String priv : REQUIRED_PRIVILEGES) {
+            if (!priv.equals(missingPrivilege)) {
+                Privilege privilege = userService.getPrivilege(priv);
+                if (privilege != null) {
+                    privileges.add(privilege);
+                }
+            }
+        }
+        role.setPrivileges(privileges);
+        userService.saveRole(role);
+
+        User user = new User(person);
+        user.setUsername("test_user_" + UUID.randomUUID());
+        user.setSystemId("test_" + UUID.randomUUID());
+        user.addRole(role);
+        userService.createUser(user, TEST_PASSWORD);
+        return user;
+    }
+
+    private SearchRequest validRequest() {
+        Condition leaf = new Condition();
+        leaf.setField("episodeOfCare.startDate");
+        leaf.setComparator("gt");
+        leaf.setValue("2024-01-01");
+
+        Condition criteria = new Condition();
+        criteria.setOperator(ConditionOperator.AND);
+        criteria.setConditions(Collections.singletonList(leaf));
+
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(criteria);
+        return request;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/service/impl/EpisodeSearchServiceImplTest.java
@@ -1,0 +1,124 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.service.impl;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.module.episodes.dao.EpisodeSearchDAO;
+import org.openmrs.module.episodes.search.BuiltQuery;
+import org.openmrs.module.episodes.search.criteria.Condition;
+import org.openmrs.module.episodes.search.criteria.ConditionOperator;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EpisodeSearchServiceImplTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private EpisodeSearchDAO episodeSearchDAO;
+
+    @InjectMocks
+    private EpisodeSearchServiceImpl episodeSearchService;
+
+    @Test
+    public void shouldDelegateToDAOForValidRequest() {
+        when(episodeSearchDAO.search(any(BuiltQuery.class))).thenReturn(Collections.emptyList());
+
+        episodeSearchService.search(validRequest());
+
+        verify(episodeSearchDAO, times(1)).search(any(BuiltQuery.class));
+    }
+
+    @Test
+    public void shouldPassBuiltHqlToDAO() {
+        when(episodeSearchDAO.search(any(BuiltQuery.class))).thenReturn(Collections.emptyList());
+        ArgumentCaptor<BuiltQuery> captor = ArgumentCaptor.forClass(BuiltQuery.class);
+
+        episodeSearchService.search(validRequest());
+
+        verify(episodeSearchDAO).search(captor.capture());
+        assertThat(captor.getValue().getHql(), notNullValue());
+        assertThat(captor.getValue().getHql(), containsString("e.dateStarted > :param0"));
+    }
+
+    @Test
+    public void shouldThrowBeforeCallingDAOWhenOrOperatorUsed() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("'OR'");
+
+        Condition criteria = new Condition();
+        criteria.setOperator(ConditionOperator.OR);
+        criteria.setConditions(Collections.singletonList(leaf("episodeOfCare.startDate", "gt", "2024-01-01")));
+
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(criteria);
+
+        episodeSearchService.search(request);
+
+        verify(episodeSearchDAO, times(0)).search(any());
+    }
+
+    @Test
+    public void shouldThrowBeforeCallingDAOForUnknownField() {
+        thrown.expect(InvalidSearchCriteriaException.class);
+        thrown.expectMessage("Unknown search field");
+
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(leaf("episode.unknownField", "eq", "val"));
+
+        episodeSearchService.search(request);
+
+        verify(episodeSearchDAO, times(0)).search(any());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNoResults() {
+        when(episodeSearchDAO.search(any(BuiltQuery.class))).thenReturn(Collections.emptyList());
+
+        assertThat(episodeSearchService.search(validRequest()).size(), is(0));
+    }
+
+    private SearchRequest validRequest() {
+        SearchRequest request = new SearchRequest();
+        request.setEntity("episodeOfCare");
+        request.setCriteria(leaf("episodeOfCare.startDate", "gt", "2024-01-01"));
+        return request;
+    }
+
+    private Condition leaf(String field, String comparator, String value) {
+        Condition c = new Condition();
+        c.setField(field);
+        c.setComparator(comparator);
+        c.setValue(value);
+        return c;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/episodes/service/impl/PatientStateSelectionTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/service/impl/PatientStateSelectionTest.java
@@ -1,0 +1,99 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.service.impl;
+
+import org.junit.Test;
+import org.openmrs.PatientState;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PatientStateSelectionTest {
+
+    @Test
+    public void shouldReturnNullWhenNoStates() {
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(Collections.emptySet()), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullWhenAllStatesAreVoided() {
+        PatientState voided = state(date(2024, 1, 1), null);
+        voided.setVoided(true);
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(voided)), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnSingleActiveState() {
+        PatientState active = state(date(2024, 1, 1), null);
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(active)), is(active));
+    }
+
+    @Test
+    public void shouldReturnActiveStateOverEndedState() {
+        PatientState ended = state(date(2023, 1, 1), date(2023, 6, 1));
+        PatientState active = state(date(2024, 1, 1), null);
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(ended, active)), is(active));
+    }
+
+    @Test
+    public void shouldReturnLatestStartDateWhenMultipleActiveStates() {
+        PatientState earlier = state(date(2023, 1, 1), null);
+        PatientState later = state(date(2024, 6, 1), null);
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(earlier, later)), is(later));
+    }
+
+    @Test
+    public void shouldReturnLatestEndDateWhenAllStatesAreEnded() {
+        PatientState older = state(date(2022, 1, 1), date(2022, 12, 31));
+        PatientState newer = state(date(2023, 1, 1), date(2023, 12, 31));
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(older, newer)), is(newer));
+    }
+
+    @Test
+    public void shouldIgnoreVoidedStatesWhenSelectingCurrent() {
+        PatientState active = state(date(2023, 1, 1), null);
+        PatientState voidedActive = state(date(2024, 1, 1), null);
+        voidedActive.setVoided(true);
+
+        assertThat(EpisodeSearchServiceImpl.selectCurrentState(setOf(active, voidedActive)), is(active));
+    }
+
+    private PatientState state(Date startDate, Date endDate) {
+        PatientState s = new PatientState();
+        s.setStartDate(startDate);
+        s.setEndDate(endDate);
+        s.setVoided(false);
+        return s;
+    }
+
+    private Date date(int year, int month, int day) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month - 1, day, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    private Set<PatientState> setOf(PatientState... states) {
+        return new LinkedHashSet<>(Arrays.asList(states));
+    }
+}

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -20,6 +20,10 @@
     </licenses>
     <dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>${project.parent.groupId}</groupId>
 			<artifactId>${project.parent.artifactId}-api</artifactId>
 			<version>${project.parent.version}</version>

--- a/omod/src/main/java/org/openmrs/module/episodes/web/controller/EpisodeSearchController.java
+++ b/omod/src/main/java/org/openmrs/module/episodes/web/controller/EpisodeSearchController.java
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.episodes.web.controller;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.episodes.search.dto.EpisodeSearchResultDTO;
+import org.openmrs.module.episodes.search.exceptions.InvalidSearchCriteriaException;
+import org.openmrs.module.episodes.search.criteria.SearchRequest;
+import org.openmrs.module.episodes.service.EpisodeSearchService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequestMapping("/rest/v1/episode")
+public class EpisodeSearchController {
+
+    private EpisodeSearchService episodeSearchService;
+
+    @PostConstruct
+    public void init() {
+        List<EpisodeSearchService> services = Context.getRegisteredComponents(EpisodeSearchService.class);
+        if (services.isEmpty()) {
+            throw new IllegalStateException("EpisodeSearchService not found in application context");
+        }
+        episodeSearchService = services.get(0);
+    }
+
+    @RequestMapping(
+            value = "/search",
+            method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> search(@RequestBody SearchRequest request) {
+        try {
+            List<EpisodeSearchResultDTO> results = episodeSearchService.search(request);
+            Map<String, Object> response = new HashMap<>();
+            response.put("results", results);
+            return ResponseEntity.ok(response);
+        } catch (InvalidSearchCriteriaException e) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", e.getMessage());
+            return ResponseEntity.status(e.getStatus().getCode()).body(error);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<mockitoVersion>3.5.11</mockitoVersion>
 		<javaxServletVersion>4.0.1</javaxServletVersion>
 		<webServices.version>2.29.0</webServices.version>
+		<lombokVersion>1.18.30</lombokVersion>
 	</properties>
 
 	<profiles>
@@ -197,6 +198,12 @@
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod</artifactId>
 				<version>${webServices.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.projectlombok</groupId>
+				<artifactId>lombok</artifactId>
+				<version>${lombokVersion}</version>
 				<scope>provided</scope>
 			</dependency>
         </dependencies>


### PR DESCRIPTION
**JIRA** → [BAH-4876](https://bahmni.atlassian.net/browse/BAH-4876)

Implements a criteria-driven Episode of Care search endpoint for the openmrs-module-episodes module.

- POST /rest/v1/episode/search accepts a structured JSON criteria payload with AND operator, supporting leaf conditions ({ field, comparator, value }) and grouped conditions for paired fields (identifiers, program attributes)
- Supports 12 searchable fields across three namespaces — episodeOfCare.*, program.*, patient.* — mapped to HQL via a field registry with lazy JOIN addition
- Returns a structured response with patient (uuid, all identifiers, person with preferred name parts), patientPrograms[] (each with PatientProgram uuid, location, attributes, and nested program definition), and careManager (uuid, display, identifier, person)
- All dates returned as yyyy-MM-dd'T'HH:mm:ss.SSSZ UTC, matching Bahmni convention
- Access guarded by @Authorized(requireAll = true) across 7 privileges; privilege constants centralised in EpisodeSearchPrivileges
- OR operator → 422, unknown field → 400, invalid comparator → 400

## Sample request

```
{
  "entity": "episodeOfCare",
  "criteria": {
    "operator": "AND",
    "conditions": [
      { "field": "program.uuid", "comparator": "eq", "value": "0f554494-1192-4f02-85ee-4f0c2610f789" },
      { "field": "episodeOfCare.startDate", "comparator": "gt", "value": "2024-01-01" },
      {
        "operator": "AND",
        "conditions": [
          { "field": "patient.identifiers.kind", "comparator": "eq", "value": "Patient Identifier" },
          { "field": "patient.identifiers.value", "comparator": "eq", "value": "PA000004" }
        ]
      }
    ]
  }
}
```

## Sample response

```
{
  "results": [
    {
      "uuid": "7d9ec6e6-943c-4ecd-ac24-7a71443ab052",
      "status": "ACTIVE",
      "dateStarted": "2026-07-20T07:25:22.000+0000",
      "dateEnded": null,
      "patient": {
        "uuid": "fb2ab3e7-33fd-
        "identifiers": [
          {
            "display": "Patient Identifier = PA000004",
            "uuid": "ed460f4d-a
            "identifier": "PA000004",
            "identifierType": {play": "Patient Identifier" },
            "location": null,
            "preferred": true
          },
          {
            "display": "Passport Number = JKHGJUR23432",
            "uuid": "66301431-.
            "identifier": "JKHGJUR23432",
            "identifierType": {play": "Passport Number" },
            "location": { "uuid": "7672b695-...", "display": "IOM MHAC NAIROBI" },
            "preferred": false
          }
        ],
        "person": {
          "uuid": "fb2ab3e7-33f
          "gender": "M",
          "age": 36,
          "birthdate": "1989-08-23T00:00:00.000+0000",
          "birthdateEstimated":
          "preferredName": {
            "uuid": "65e70c1c-.
            "givenName": "Lora",
            "middleName": "",
            "familyName": "Bharadwaj",
            "familyName2": null
            "voided": false
          }
        },
        "voided": false
      },
      "patientPrograms": [
        {
          "uuid": "efb680db-094
          "location": null,
          "attributes": [
            {
              "attributeType":
              "value": "UK",
              "uuid": "7ba769d5
            }
          ],
          "program": {
            "uuid": "0f554494-1
            "name": "UK Health Assessment",
            "retired": false,
            "description": "Program for tracking UK Health Assessment",
            "concept": { "uuid""Health Assessment Program Type"}
          }
        }
      ],
      "careManager": {
        "uuid": null,
        "display": null,
        "identifier": null,
        "person": null
      }
    }
  ]
}
```

[BAH-4876]: https://bahmni.atlassian.net/browse/BAH-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ