### PR TITLE
BAH-5022 | Add. Filter Program Status And Status Date By Current State

### DIFF
--- a/api/src/main/java/org/openmrs/module/episodes/dao/impl/PatientProgramSearchDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/episodes/dao/impl/PatientProgramSearchDAOImpl.java
@@ -59,7 +59,7 @@ public class PatientProgramSearchDAOImpl implements PatientProgramSearchDAO {
         predicates.add(cb.isFalse(root.get("voided")));
         predicates.add(cb.isFalse(patientProgram.get("voided")));
 
-        EpisodeQueryContext context = new EpisodeQueryContext(cb, root, patientProgram, predicates);
+        EpisodeQueryContext context = new EpisodeQueryContext(cb, root, patientProgram, predicates, query);
         criteriaBuilder.apply(context, searchCriteria);
         query.select(root).distinct(true).where(predicates.toArray(new Predicate[0]));
 

--- a/api/src/main/java/org/openmrs/module/episodes/search/builder/EpisodeQueryContext.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/builder/EpisodeQueryContext.java
@@ -13,6 +13,7 @@ import org.bahmni.search.builder.QueryContext;
 import org.openmrs.module.episodes.Episode;
 
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -23,13 +24,16 @@ public class EpisodeQueryContext extends QueryContext<Episode> {
 
     public final Root<Episode> episodeRoot;
     public final From<?, ?> patientProgramJoin;
+    public final CriteriaQuery<?> query;
 
     public EpisodeQueryContext(CriteriaBuilder criteriaBuilder,
                                Root<Episode> episodeRoot,
                                From<?, ?> patientProgramJoin,
-                               List<Predicate> predicates) {
+                               List<Predicate> predicates,
+                               CriteriaQuery<?> query) {
         super(criteriaBuilder, episodeRoot, predicates);
         this.episodeRoot = episodeRoot;
         this.patientProgramJoin = patientProgramJoin;
+        this.query = query;
     }
 }

--- a/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
@@ -77,47 +77,50 @@ public class PatientProgramJoinResolver {
     private Predicate buildCurrentStateRestriction(EpisodeQueryContext queryContext, From<?, ?> statesJoin) {
         CriteriaBuilder cb = queryContext.criteriaBuilder;
         Subquery<Integer> subquery = queryContext.query.subquery(Integer.class);
-        Root<PatientState> other = subquery.from(PatientState.class);
-        From<?, ?> current = statesJoin;
+        Root<PatientState> stateA = subquery.from(PatientState.class);
+        From<?, ?> stateB = statesJoin;
 
-        subquery.select(other.<Integer>get(STATE_ID));
+        subquery.select(stateA.get(STATE_ID));
         subquery.where(
-                cb.equal(other.get(PATIENT_PROGRAM), current.get(PATIENT_PROGRAM)),
-                cb.isFalse(other.get(VOIDED)),
-                cb.notEqual(other.get(STATE_ID), current.get(STATE_ID)),
-                otherOutranksCurrent(cb, other, current));
+                cb.equal(stateA.get(PATIENT_PROGRAM), stateB.get(PATIENT_PROGRAM)),
+                cb.isFalse(stateA.get(VOIDED)),
+                cb.notEqual(stateA.get(STATE_ID), stateB.get(STATE_ID)),
+                isMoreRecentThan(cb, stateA, stateB));
 
+        // If no other state is more recent than stateB, then stateB is the current one — keep it.
         return cb.not(cb.exists(subquery));
     }
 
-    private Predicate otherOutranksCurrent(CriteriaBuilder cb, From<?, ?> other, From<?, ?> current) {
-        Path<Date> otherEnd = other.get(END_DATE);
-        Path<Date> currentEnd = current.get(END_DATE);
-        Path<Date> otherStart = other.get(START_DATE);
-        Path<Date> currentStart = current.get(START_DATE);
-        Path<Integer> otherId = other.get(STATE_ID);
-        Path<Integer> currentId = current.get(STATE_ID);
+    // Does stateA come later (chronologically) than stateB?
+    private Predicate isMoreRecentThan(CriteriaBuilder cb, From<?, ?> stateA, From<?, ?> stateB) {
+        Path<Date> stateAEndDate = stateA.get(END_DATE);
+        Path<Date> stateBEndDate = stateB.get(END_DATE);
+        Path<Date> stateAStartDate = stateA.get(START_DATE);
+        Path<Date> stateBStartDate = stateB.get(START_DATE);
+        Path<Integer> stateAId = stateA.get(STATE_ID);
+        Path<Integer> stateBId = stateB.get(STATE_ID);
 
-        Predicate otherActive = cb.isNull(otherEnd);
-        Predicate currentActive = cb.isNull(currentEnd);
+        Predicate stateAHasNoEndDate = cb.isNull(stateAEndDate);
+        Predicate stateBHasNoEndDate = cb.isNull(stateBEndDate);
 
-        Predicate otherActiveOutranksEnded = cb.and(otherActive, cb.isNotNull(currentEnd));
+        // A state with no end date (still active) is always more recent than one that has already ended.
+        Predicate currentActiveState = cb.and(stateAHasNoEndDate, cb.isNotNull(stateBEndDate));
 
-        Predicate bothActive = cb.and(otherActive, currentActive);
-        Predicate otherIsMoreRecentActiveState = cb.and(bothActive, cb.or(
-                cb.and(cb.isNotNull(otherStart), cb.isNull(currentStart)),
-                cb.and(cb.isNotNull(otherStart), cb.isNotNull(currentStart),
-                        cb.greaterThan(otherStart, currentStart)),
-                cb.and(cb.isNotNull(otherStart), cb.isNotNull(currentStart),
-                        cb.equal(otherStart, currentStart), cb.lessThan(otherId, currentId)),
-                cb.and(cb.isNull(otherStart), cb.isNull(currentStart), cb.lessThan(otherId, currentId))));
+        Predicate isBothActive = cb.and(stateAHasNoEndDate, stateBHasNoEndDate);
+        Predicate stateAStartedRecently = cb.and(isBothActive, cb.or(
+                cb.and(cb.isNotNull(stateAStartDate), cb.isNull(stateBStartDate)),
+                cb.and(cb.isNotNull(stateAStartDate), cb.isNotNull(stateBStartDate),
+                        cb.greaterThan(stateAStartDate, stateBStartDate)),
+                cb.and(cb.isNotNull(stateAStartDate), cb.isNotNull(stateBStartDate),
+                        cb.equal(stateAStartDate, stateBStartDate), cb.lessThan(stateAId, stateBId)),
+                cb.and(cb.isNull(stateAStartDate), cb.isNull(stateBStartDate), cb.lessThan(stateAId, stateBId))));
 
-        Predicate bothEnded = cb.and(cb.isNotNull(otherEnd), cb.isNotNull(currentEnd));
-        Predicate otherIsMoreRecentEndedState = cb.and(bothEnded, cb.or(
-                cb.greaterThan(otherEnd, currentEnd),
-                cb.and(cb.equal(otherEnd, currentEnd), cb.lessThan(otherId, currentId))));
+        Predicate bothEnded = cb.and(cb.isNotNull(stateAEndDate), cb.isNotNull(stateBEndDate));
+        Predicate stateAEndedRecently = cb.and(bothEnded, cb.or(
+                cb.greaterThan(stateAEndDate, stateBEndDate),
+                cb.and(cb.equal(stateAEndDate, stateBEndDate), cb.lessThan(stateAId, stateBId))));
 
-        return cb.or(otherActiveOutranksEnded, otherIsMoreRecentActiveState, otherIsMoreRecentEndedState);
+        return cb.or(currentActiveState, stateAStartedRecently, stateAEndedRecently);
     }
 
     From<?, ?> joinStateConcept(EpisodeQueryContext queryContext) {

--- a/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
@@ -10,14 +10,25 @@
 package org.openmrs.module.episodes.search.builder;
 
 import org.bahmni.search.builder.JoinResolvers;
+import org.openmrs.PatientState;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import java.util.Date;
 
 public class PatientProgramJoinResolver {
 
     private static final String VOIDED = "voided";
+    private static final String START_DATE = "startDate";
+    private static final String END_DATE = "endDate";
+    private static final String STATE_ID = "patientStateId";
+    private static final String PATIENT_PROGRAM = "patientProgram";
 
     From<?, ?> joinCareManager(EpisodeQueryContext queryContext) {
         return queryContext.joinCache.computeIfAbsent("careManager",
@@ -41,10 +52,72 @@ public class PatientProgramJoinResolver {
 
     From<?, ?> joinStates(EpisodeQueryContext queryContext) {
         return queryContext.joinCache.computeIfAbsent("patientState", key -> {
-            Join<?, ?> statesJoin = queryContext.patientProgramJoin.join("states", JoinType.INNER);
+            From<?, ?> patientProgramForFilter = joinPatientProgramForFilter(queryContext);
+            Join<?, ?> statesJoin = patientProgramForFilter.join("states", JoinType.INNER);
             queryContext.predicates.add(queryContext.criteriaBuilder.isFalse(statesJoin.get(VOIDED)));
+            queryContext.predicates.add(buildCurrentStateRestriction(queryContext, statesJoin));
             return statesJoin;
         });
+    }
+
+    private From<?, ?> joinPatientProgramForFilter(EpisodeQueryContext queryContext) {
+        return queryContext.joinCache.computeIfAbsent("patientProgramFilter", key -> {
+            Join<?, ?> filterJoin = queryContext.episodeRoot.join("patientPrograms", JoinType.INNER);
+            queryContext.predicates.add(queryContext.criteriaBuilder.isFalse(filterJoin.get(VOIDED)));
+            return filterJoin;
+        });
+    }
+
+    /**
+     * Restricts the joined patient state to the "current" state of its program, matching the
+     * semantics of selectCurrentState: active states (no end date) outrank ended states; within
+     * a group the latest date wins (startDate for active, endDate for ended, with non-null
+     * startDate preferred over null); date ties are broken by the lowest patientStateId.
+     */
+    private Predicate buildCurrentStateRestriction(EpisodeQueryContext queryContext, From<?, ?> statesJoin) {
+        CriteriaBuilder cb = queryContext.criteriaBuilder;
+        Subquery<Integer> subquery = queryContext.query.subquery(Integer.class);
+        Root<PatientState> other = subquery.from(PatientState.class);
+        From<?, ?> current = statesJoin;
+
+        subquery.select(other.<Integer>get(STATE_ID));
+        subquery.where(
+                cb.equal(other.get(PATIENT_PROGRAM), current.get(PATIENT_PROGRAM)),
+                cb.isFalse(other.get(VOIDED)),
+                cb.notEqual(other.get(STATE_ID), current.get(STATE_ID)),
+                otherOutranksCurrent(cb, other, current));
+
+        return cb.not(cb.exists(subquery));
+    }
+
+    private Predicate otherOutranksCurrent(CriteriaBuilder cb, From<?, ?> other, From<?, ?> current) {
+        Path<Date> otherEnd = other.get(END_DATE);
+        Path<Date> currentEnd = current.get(END_DATE);
+        Path<Date> otherStart = other.get(START_DATE);
+        Path<Date> currentStart = current.get(START_DATE);
+        Path<Integer> otherId = other.get(STATE_ID);
+        Path<Integer> currentId = current.get(STATE_ID);
+
+        Predicate otherActive = cb.isNull(otherEnd);
+        Predicate currentActive = cb.isNull(currentEnd);
+
+        Predicate otherActiveOutranksEnded = cb.and(otherActive, cb.isNotNull(currentEnd));
+
+        Predicate bothActive = cb.and(otherActive, currentActive);
+        Predicate otherIsMoreRecentActiveState = cb.and(bothActive, cb.or(
+                cb.and(cb.isNotNull(otherStart), cb.isNull(currentStart)),
+                cb.and(cb.isNotNull(otherStart), cb.isNotNull(currentStart),
+                        cb.greaterThan(otherStart, currentStart)),
+                cb.and(cb.isNotNull(otherStart), cb.isNotNull(currentStart),
+                        cb.equal(otherStart, currentStart), cb.lessThan(otherId, currentId)),
+                cb.and(cb.isNull(otherStart), cb.isNull(currentStart), cb.lessThan(otherId, currentId))));
+
+        Predicate bothEnded = cb.and(cb.isNotNull(otherEnd), cb.isNotNull(currentEnd));
+        Predicate otherIsMoreRecentEndedState = cb.and(bothEnded, cb.or(
+                cb.greaterThan(otherEnd, currentEnd),
+                cb.and(cb.equal(otherEnd, currentEnd), cb.lessThan(otherId, currentId))));
+
+        return cb.or(otherActiveOutranksEnded, otherIsMoreRecentActiveState, otherIsMoreRecentEndedState);
     }
 
     From<?, ?> joinStateConcept(EpisodeQueryContext queryContext) {

--- a/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramCriteriaBuilderTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramCriteriaBuilderTest.java
@@ -20,6 +20,7 @@ import org.bahmni.search.exceptions.InvalidSearchCriteriaException;
 import org.bahmni.search.model.SearchCondition;
 
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -70,8 +71,9 @@ public class PatientProgramCriteriaBuilderTest {
         CriteriaBuilder mockCriteriaBuilder = mock(CriteriaBuilder.class);
         Root<Episode> mockEpisodeRoot = mock(Root.class);
         From<?, ?> mockPatientProgramJoin = mock(From.class);
+        CriteriaQuery<?> mockQuery = mock(CriteriaQuery.class);
         List<Predicate> predicates = new ArrayList<>();
-        return new EpisodeQueryContext(mockCriteriaBuilder, mockEpisodeRoot, mockPatientProgramJoin, predicates);
+        return new EpisodeQueryContext(mockCriteriaBuilder, mockEpisodeRoot, mockPatientProgramJoin, predicates, mockQuery);
     }
 
     private SearchCondition createLeafCriteria(String fieldName, String comparator, String value) {

--- a/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
@@ -48,14 +48,11 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     private static final String DATE_FROM = "2024-01-01T00:00:00.000+0000";
     private static final String DATE_TO = "2024-12-31T23:59:59.000+0000";
 
-    // Workflow states of program 1 (standard test dataset) and the concept uuids they resolve to.
-    private static final String STATE_A_UUID = "e938129e-248a-482a-acea-f85127251472"; // -> concept 17
-    private static final String STATUS_A_CONCEPT = "54d2dce5-0357-4253-a91a-85ce519137f5"; // concept 17
-    private static final String STATE_B_UUID = "92584cdc-6a20-4c84-a659-e035e45d36b0"; // workflow 1 -> concept 16
-    private static final String STATUS_B_CONCEPT = "7d104a6f-8337-4afa-b936-41083a5d9d88"; // concept 16
-    // Workflow 2 state -> concept 17; used where two *active* states must live in different workflows
-    // (OpenMRS forbids multiple active states in the same workflow).
-    private static final String STATE_WF2_UUID = "860b3a13-d4b1-4f0a-b526-278652fa1809"; // workflow 2 -> concept 17
+    private static final String STATE_A_UUID = "e938129e-248a-482a-acea-f85127251472";
+    private static final String STATUS_A_CONCEPT = "54d2dce5-0357-4253-a91a-85ce519137f5";
+    private static final String STATE_B_UUID = "92584cdc-6a20-4c84-a659-e035e45d36b0";
+    private static final String STATUS_B_CONCEPT = "7d104a6f-8337-4afa-b936-41083a5d9d88";
+    private static final String STATE_WF2_UUID = "860b3a13-d4b1-4f0a-b526-278652fa1809";
 
     @Autowired
     private EpisodeSearchService searchService;
@@ -211,8 +208,8 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test
     public void shouldMatchCurrentStatusAndItsStartDateRange() {
         PatientProgram pp = newPatientProgram();
-        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old ended state
-        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);            // current active state
+        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1));
+        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(pp);
 
         SearchCondition criteria = group(
@@ -230,8 +227,8 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test
     public void shouldNotMatchAHistoricalNonCurrentStatus() {
         PatientProgram pp = newPatientProgram();
-        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old ended state (not current)
-        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);            // current active state
+        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1));
+        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(pp);
 
         List<Map<String, Object>> results = searchService.search(
@@ -244,8 +241,8 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test
     public void shouldMatchLatestEndedStatusWhenAllStatesEnded() {
         PatientProgram pp = newPatientProgram();
-        addState(pp, STATE_B_UUID, date(2023, 1, 1), date(2023, 6, 1));  // earlier ended
-        addState(pp, STATE_A_UUID, date(2024, 1, 1), date(2024, 6, 1));  // latest ended -> current
+        addState(pp, STATE_B_UUID, date(2023, 1, 1), date(2023, 6, 1));
+        addState(pp, STATE_A_UUID, date(2024, 1, 1), date(2024, 6, 1));
         saveEpisodeWith(pp);
 
         List<Map<String, Object>> latest = searchService.search(
@@ -263,8 +260,8 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test
     public void shouldBreakStartDateTieByLowestPatientStateId() {
         PatientProgram pp = newPatientProgram();
-        addState(pp, STATE_B_UUID, date(2024, 6, 15), null);    // workflow 1, concept 16, lower id
-        addState(pp, STATE_WF2_UUID, date(2024, 6, 15), null);  // workflow 2, concept 17, higher id
+        addState(pp, STATE_B_UUID, date(2024, 6, 15), null);
+        addState(pp, STATE_WF2_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(pp);
 
         List<Map<String, Object>> lowerId = searchService.search(
@@ -282,13 +279,13 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test
     public void shouldResolveCurrentStatusPerPatientProgram() {
         PatientProgram ppA = newPatientProgram();
-        addState(ppA, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old
-        addState(ppA, STATE_A_UUID, date(2024, 6, 15), null);            // current = A
+        addState(ppA, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1));
+        addState(ppA, STATE_A_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(ppA);
 
         PatientProgram ppB = newPatientProgram();
-        addState(ppB, STATE_A_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old
-        addState(ppB, STATE_B_UUID, date(2024, 6, 15), null);            // current = B
+        addState(ppB, STATE_A_UUID, date(2020, 1, 1), date(2021, 1, 1));
+        addState(ppB, STATE_B_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(ppB);
 
         List<Map<String, Object>> currentA = searchService.search(

--- a/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
@@ -14,6 +14,7 @@ import org.openmrs.module.episodes.service.EpisodeSearchService;
 import org.junit.Test;
 import org.openmrs.Location;
 import org.openmrs.PatientProgram;
+import org.openmrs.PatientState;
 import org.openmrs.Person;
 import org.openmrs.PersonName;
 import org.openmrs.Provider;
@@ -46,6 +47,15 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     private static final String LT = "lt";
     private static final String DATE_FROM = "2024-01-01T00:00:00.000+0000";
     private static final String DATE_TO = "2024-12-31T23:59:59.000+0000";
+
+    // Workflow states of program 1 (standard test dataset) and the concept uuids they resolve to.
+    private static final String STATE_A_UUID = "e938129e-248a-482a-acea-f85127251472"; // -> concept 17
+    private static final String STATUS_A_CONCEPT = "54d2dce5-0357-4253-a91a-85ce519137f5"; // concept 17
+    private static final String STATE_B_UUID = "92584cdc-6a20-4c84-a659-e035e45d36b0"; // workflow 1 -> concept 16
+    private static final String STATUS_B_CONCEPT = "7d104a6f-8337-4afa-b936-41083a5d9d88"; // concept 16
+    // Workflow 2 state -> concept 17; used where two *active* states must live in different workflows
+    // (OpenMRS forbids multiple active states in the same workflow).
+    private static final String STATE_WF2_UUID = "860b3a13-d4b1-4f0a-b526-278652fa1809"; // workflow 2 -> concept 17
 
     @Autowired
     private EpisodeSearchService searchService;
@@ -196,6 +206,120 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     @Test(expected = InvalidSearchCriteriaException.class)
     public void shouldThrowExceptionForInvalidDateFormat() {
         searchService.search(requestWith(leaf(SearchFields.EOC_START_DATE, GT, "01/01/2024")));
+    }
+
+    @Test
+    public void shouldMatchCurrentStatusAndItsStartDateRange() {
+        PatientProgram pp = newPatientProgram();
+        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old ended state
+        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);            // current active state
+        saveEpisodeWith(pp);
+
+        SearchCondition criteria = group(
+                leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_A_CONCEPT),
+                leaf(SearchFields.PROGRAM_STATUS_DATE, GT, DATE_FROM),
+                leaf(SearchFields.PROGRAM_STATUS_DATE, LT, DATE_TO)
+        );
+
+        List<Map<String, Object>> results = searchService.search(requestWith(criteria)).getResults();
+
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).get("uuid"), is(pp.getUuid()));
+    }
+
+    @Test
+    public void shouldNotMatchAHistoricalNonCurrentStatus() {
+        PatientProgram pp = newPatientProgram();
+        addState(pp, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old ended state (not current)
+        addState(pp, STATE_A_UUID, date(2024, 6, 15), null);            // current active state
+        saveEpisodeWith(pp);
+
+        List<Map<String, Object>> results = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
+        ).getResults();
+
+        assertThat(results.size(), is(0));
+    }
+
+    @Test
+    public void shouldMatchLatestEndedStatusWhenAllStatesEnded() {
+        PatientProgram pp = newPatientProgram();
+        addState(pp, STATE_B_UUID, date(2023, 1, 1), date(2023, 6, 1));  // earlier ended
+        addState(pp, STATE_A_UUID, date(2024, 1, 1), date(2024, 6, 1));  // latest ended -> current
+        saveEpisodeWith(pp);
+
+        List<Map<String, Object>> latest = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_A_CONCEPT))
+        ).getResults();
+        assertThat(latest.size(), is(1));
+        assertThat(latest.get(0).get("uuid"), is(pp.getUuid()));
+
+        List<Map<String, Object>> earlier = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
+        ).getResults();
+        assertThat(earlier.size(), is(0));
+    }
+
+    @Test
+    public void shouldBreakStartDateTieByLowestPatientStateId() {
+        PatientProgram pp = newPatientProgram();
+        addState(pp, STATE_B_UUID, date(2024, 6, 15), null);    // workflow 1, concept 16, lower id
+        addState(pp, STATE_WF2_UUID, date(2024, 6, 15), null);  // workflow 2, concept 17, higher id
+        saveEpisodeWith(pp);
+
+        List<Map<String, Object>> lowerId = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
+        ).getResults();
+        assertThat(lowerId.size(), is(1));
+        assertThat(lowerId.get(0).get("uuid"), is(pp.getUuid()));
+
+        List<Map<String, Object>> higherId = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_A_CONCEPT))
+        ).getResults();
+        assertThat(higherId.size(), is(0));
+    }
+
+    @Test
+    public void shouldResolveCurrentStatusPerPatientProgram() {
+        PatientProgram ppA = newPatientProgram();
+        addState(ppA, STATE_B_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old
+        addState(ppA, STATE_A_UUID, date(2024, 6, 15), null);            // current = A
+        saveEpisodeWith(ppA);
+
+        PatientProgram ppB = newPatientProgram();
+        addState(ppB, STATE_A_UUID, date(2020, 1, 1), date(2021, 1, 1)); // old
+        addState(ppB, STATE_B_UUID, date(2024, 6, 15), null);            // current = B
+        saveEpisodeWith(ppB);
+
+        List<Map<String, Object>> currentA = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_A_CONCEPT))
+        ).getResults();
+        assertThat(currentA.size(), is(1));
+        assertThat(currentA.get(0).get("uuid"), is(ppA.getUuid()));
+
+        List<Map<String, Object>> currentB = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
+        ).getResults();
+        assertThat(currentB.size(), is(1));
+        assertThat(currentB.get(0).get("uuid"), is(ppB.getUuid()));
+    }
+
+    private PatientProgram newPatientProgram() {
+        PatientProgram pp = new PatientProgram();
+        pp.setPatient(patientService.getPatient(2));
+        pp.setProgram(programWorkflowService.getProgram(1));
+        pp.setDateEnrolled(date(2020, 1, 1));
+        return programWorkflowService.savePatientProgram(pp);
+    }
+
+    private PatientProgram addState(PatientProgram pp, String stateUuid, Date startDate, Date endDate) {
+        PatientState state = new PatientState();
+        state.setPatientProgram(pp);
+        state.setState(programWorkflowService.getStateByUuid(stateUuid));
+        state.setStartDate(startDate);
+        state.setEndDate(endDate);
+        pp.getStates().add(state);
+        return programWorkflowService.savePatientProgram(pp);
     }
 
     private void saveEpisodeWith(PatientProgram pp) {


### PR DESCRIPTION
JIRA -> [BAH-5022](https://bahmni.atlassian.net/browse/BAH-5022)

Restrict program.status / program.statusDate to the current patient state via a correlated NOT EXISTS subquery (active > ended, latest date, lowest patientStateId tie-break). Base the states join on a non-fetch program join to avoid Hibernate pruning it. 

[BAH-5022]: https://bahmni.atlassian.net/browse/BAH-5022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ