### PR TITLE
BAH-5022 | Fix. Break Current State Ties By Highest Patient State Id

### DIFF
--- a/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
+++ b/api/src/main/java/org/openmrs/module/episodes/search/builder/PatientProgramJoinResolver.java
@@ -72,7 +72,7 @@ public class PatientProgramJoinResolver {
      * Restricts the joined patient state to the "current" state of its program, matching the
      * semantics of selectCurrentState: active states (no end date) outrank ended states; within
      * a group the latest date wins (startDate for active, endDate for ended, with non-null
-     * startDate preferred over null); date ties are broken by the lowest patientStateId.
+     * startDate preferred over null); date ties are broken by the highest patientStateId.
      */
     private Predicate buildCurrentStateRestriction(EpisodeQueryContext queryContext, From<?, ?> statesJoin) {
         CriteriaBuilder cb = queryContext.criteriaBuilder;
@@ -112,13 +112,13 @@ public class PatientProgramJoinResolver {
                 cb.and(cb.isNotNull(stateAStartDate), cb.isNotNull(stateBStartDate),
                         cb.greaterThan(stateAStartDate, stateBStartDate)),
                 cb.and(cb.isNotNull(stateAStartDate), cb.isNotNull(stateBStartDate),
-                        cb.equal(stateAStartDate, stateBStartDate), cb.lessThan(stateAId, stateBId)),
-                cb.and(cb.isNull(stateAStartDate), cb.isNull(stateBStartDate), cb.lessThan(stateAId, stateBId))));
+                        cb.equal(stateAStartDate, stateBStartDate), cb.greaterThan(stateAId, stateBId)),
+                cb.and(cb.isNull(stateAStartDate), cb.isNull(stateBStartDate), cb.greaterThan(stateAId, stateBId))));
 
         Predicate bothEnded = cb.and(cb.isNotNull(stateAEndDate), cb.isNotNull(stateBEndDate));
         Predicate stateAEndedRecently = cb.and(bothEnded, cb.or(
                 cb.greaterThan(stateAEndDate, stateBEndDate),
-                cb.and(cb.equal(stateAEndDate, stateBEndDate), cb.lessThan(stateAId, stateBId))));
+                cb.and(cb.equal(stateAEndDate, stateBEndDate), cb.greaterThan(stateAId, stateBId))));
 
         return cb.or(currentActiveState, stateAStartedRecently, stateAEndedRecently);
     }

--- a/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/search/PatientProgramSearchServiceImplITTest.java
@@ -258,22 +258,22 @@ public class PatientProgramSearchServiceImplITTest extends BaseModuleContextSens
     }
 
     @Test
-    public void shouldBreakStartDateTieByLowestPatientStateId() {
+    public void shouldBreakStartDateTieByHighestPatientStateId() {
         PatientProgram pp = newPatientProgram();
         addState(pp, STATE_B_UUID, date(2024, 6, 15), null);
         addState(pp, STATE_WF2_UUID, date(2024, 6, 15), null);
         saveEpisodeWith(pp);
 
-        List<Map<String, Object>> lowerId = searchService.search(
-                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
-        ).getResults();
-        assertThat(lowerId.size(), is(1));
-        assertThat(lowerId.get(0).get("uuid"), is(pp.getUuid()));
-
         List<Map<String, Object>> higherId = searchService.search(
                 requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_A_CONCEPT))
         ).getResults();
-        assertThat(higherId.size(), is(0));
+        assertThat(higherId.size(), is(1));
+        assertThat(higherId.get(0).get("uuid"), is(pp.getUuid()));
+
+        List<Map<String, Object>> lowerId = searchService.search(
+                requestWith(leaf(SearchFields.PROGRAM_STATUS, EQ, STATUS_B_CONCEPT))
+        ).getResults();
+        assertThat(lowerId.size(), is(0));
     }
 
     @Test

--- a/api/src/test/java/org/openmrs/module/episodes/service/impl/PatientStateSelectionTest.java
+++ b/api/src/test/java/org/openmrs/module/episodes/service/impl/PatientStateSelectionTest.java
@@ -71,6 +71,16 @@ public class PatientStateSelectionTest {
     }
 
     @Test
+    public void shouldBreakEndDateTieByHighestPatientStateId() {
+        PatientState lowerId = state(date(2023, 1, 1), date(2023, 12, 31));
+        lowerId.setPatientStateId(1);
+        PatientState higherId = state(date(2023, 1, 1), date(2023, 12, 31));
+        higherId.setPatientStateId(2);
+
+        assertThat(PatientProgramResponseBuilder.selectCurrentState(setOf(lowerId, higherId)), is(higherId));
+    }
+
+    @Test
     public void shouldIgnoreVoidedStatesWhenSelectingCurrent() {
         PatientState active = state(date(2023, 1, 1), null);
         PatientState voidedActive = state(date(2024, 1, 1), null);


### PR DESCRIPTION
JIRA -> [BAH-5022](https://bahmni.atlassian.net/browse/BAH-5022)

Restrict program.status / program.statusDate to the current patient state via a correlated NOT EXISTS subquery (active > ended, latest date, lowest patientStateId tie-break). Base the states join on a non-fetch program join to avoid Hibernate pruning it.